### PR TITLE
library(htmltools) no longer required in knitr/rmarkdown docs

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -1,27 +1,41 @@
 #' @import digest
 NULL
 
-# htmltools provides methods for knitr::knit_print, but knitr isn't a Depends or
-# Imports of htmltools, only an Enhances. Therefore, the NAMESPACE file has to
-# declare it as an export, not an S3method. That means that R will only know to
-# use our methods if htmltools is actually attached, i.e., you have to use
-# library(htmltools) in a knitr document or else you'll get escaped HTML in your
-# document. This code snippet manually registers our methods with S3 once both
-# htmltools and knitr are loaded.
-.onLoad <- function(...) {
-  if ("knitr" %in% loadedNamespaces()) {
-    registerS3method("knit_print", "html", knit_print.html, envir = asNamespace("knitr"))
-    registerS3method("knit_print", "shiny.tag", knit_print.shiny.tag, envir = asNamespace("knitr"))
-    registerS3method("knit_print", "shiny.tag.list", knit_print.shiny.tag.list, envir = asNamespace("knitr"))
-  }
-  setHook(
-    packageEvent("knitr", "onLoad"),
-    function(...) {
-      registerS3method("knit_print", "html", knit_print.html, envir = asNamespace("knitr"))
-      registerS3method("knit_print", "shiny.tag", knit_print.shiny.tag, envir = asNamespace("knitr"))
-      registerS3method("knit_print", "shiny.tag.list", knit_print.shiny.tag.list, envir = asNamespace("knitr"))
+# Reusable function for registering a set of methods with S3 manually. The
+# methods argument is a list of character vectors, each of which has the form
+# c(package, genname, class).
+registerMethods <- function(methods) {
+  lapply(methods, function(method) {
+    pkg <- method[[1]]
+    generic <- method[[2]]
+    class <- method[[3]]
+    func <- get(paste(generic, class, sep="."))
+    if (pkg %in% loadedNamespaces()) {
+      registerS3method(generic, class, func, envir = asNamespace(pkg))
     }
-  )
+    setHook(
+      packageEvent(pkg, "onLoad"),
+      function(...) {
+        registerS3method(generic, class, func, envir = asNamespace(pkg))
+      }
+    )
+  })
+}
+
+.onLoad <- function(...) {
+  # htmltools provides methods for knitr::knit_print, but knitr isn't a Depends or
+  # Imports of htmltools, only an Enhances. Therefore, the NAMESPACE file has to
+  # declare it as an export, not an S3method. That means that R will only know to
+  # use our methods if htmltools is actually attached, i.e., you have to use
+  # library(htmltools) in a knitr document or else you'll get escaped HTML in your
+  # document. This code snippet manually registers our methods with S3 once both
+  # htmltools and knitr are loaded.
+  registerMethods(list(
+    # c(package, genname, class)
+    c("knitr", "knit_print", "html"),
+    c("knitr", "knit_print", "shiny.tag"),
+    c("knitr", "knit_print", "shiny.tag.list")
+  ))
 }
 
 depListToNamedDepList <- function(dependencies) {


### PR DESCRIPTION
Thanks to @wch for patiently working through this with me. @hadley, @yihui, does this look good? (It passes R CMD check without warnings.)

@ramnathv I'm thinking we'll need to do the same kind of thing in htmlwidgets.

cc @jjallaire
