### PR TITLE
convert the encoding to UTF-8 before writing out the content

### DIFF
--- a/R/html_print.R
+++ b/R/html_print.R
@@ -96,6 +96,7 @@ save_html <- function(html, file, background = "white", libdir = "lib") {
             rendered$html,
             "</body>",
             "</html>")
+  html <- enc2utf8(html)
 
   # write it
   writeLines(html, file, useBytes = TRUE)


### PR DESCRIPTION
Without the conversion, multi-byte characters do not work in HTML widgets. I have tested it with the DT package.

This fixes the third issue reported at rstudio/shiny-examples#2.