### PR TITLE
Always overwrite dependency files when copying them

### DIFF
--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -237,20 +237,19 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
   target_dir <- file.path(outputDir,
     paste(dependency$name, dependency$version, sep = "-"))
 
-  if (!dir_exists(target_dir)) {
+  if (!dir_exists(target_dir))
     dir.create(target_dir)
 
-    srcfiles <- file.path(dir, list.files(dir))
-    destfiles <- file.path(target_dir, list.files(dir))
-    isdir <- file.info(srcfiles)$isdir
-    destfiles <- ifelse(isdir, dirname(destfiles), destfiles)
+  srcfiles <- file.path(dir, list.files(dir))
+  destfiles <- file.path(target_dir, list.files(dir))
+  isdir <- file.info(srcfiles)$isdir
+  destfiles <- ifelse(isdir, dirname(destfiles), destfiles)
 
-    mapply(function(from, to, isdir) {
-      if (isdir && !dir_exists(to))
-        dir.create(to)
-      file.copy(from, to, overwrite = TRUE, recursive = TRUE)
-    }, srcfiles, destfiles, isdir)
-  }
+  mapply(function(from, to, isdir) {
+    if (isdir && !dir_exists(to))
+      dir.create(to)
+    file.copy(from, to, overwrite = TRUE, recursive = isdir)
+  }, srcfiles, destfiles, isdir)
 
   dependency$src$file <- normalizePath(target_dir, "/", TRUE)
 

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -200,10 +200,6 @@ urlEncodePath <- function(x) {
 #' HTML file, or to a subdirectory of that directory. This function makes it
 #' easier to perform that copy.
 #'
-#' If a subdirectory named \emph{name}-\emph{version} already exists in
-#' \code{outputDir}, then copying is not performed; the existing contents are
-#' assumed to be up-to-date.
-#'
 #' @param dependency A single HTML dependency object.
 #' @param outputDir The directory in which a subdirectory should be created for
 #'   this dependency.
@@ -237,8 +233,12 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
   target_dir <- file.path(outputDir,
     paste(dependency$name, dependency$version, sep = "-"))
 
-  if (!dir_exists(target_dir))
-    dir.create(target_dir)
+  # completely remove the target dir because we don't want possible leftover
+  # files in the target dir, e.g. we may have lib/foo.js last time, and it was
+  # removed from the original library, then the next time we copy the library
+  # over to the target dir, we want to remove this lib/foo.js as well
+  if (dir_exists(target_dir)) unlink(target_dir, recursive = TRUE)
+  dir.create(target_dir)
 
   srcfiles <- file.path(dir, list.files(dir))
   destfiles <- file.path(target_dir, list.files(dir))

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -231,13 +231,13 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
     }
   }
 
-  if (!file.exists(outputDir))
+  if (!dir_exists(outputDir))
     dir.create(outputDir)
 
   target_dir <- file.path(outputDir,
     paste(dependency$name, dependency$version, sep = "-"))
 
-  if (!file.exists(target_dir)) {
+  if (!dir_exists(target_dir)) {
     dir.create(target_dir)
 
     srcfiles <- file.path(dir, list.files(dir))
@@ -245,16 +245,20 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
     isdir <- file.info(srcfiles)$isdir
     destfiles <- ifelse(isdir, dirname(destfiles), destfiles)
 
-    mapply(function(from, to, recursive) {
-      if (recursive && !file.exists(to))
+    mapply(function(from, to, isdir) {
+      if (isdir && !dir_exists(to))
         dir.create(to)
-      file.copy(from, to, recursive=recursive)
+      file.copy(from, to, overwrite = TRUE, recursive = TRUE)
     }, srcfiles, destfiles, isdir)
   }
 
   dependency$src$file <- normalizePath(target_dir, "/", TRUE)
 
   dependency
+}
+
+dir_exists <- function(paths) {
+  utils::file_test("-d", paths)
 }
 
 # given a directory and a file, return a relative path from the directory to the

--- a/man/copyDependencyToDir.Rd
+++ b/man/copyDependencyToDir.Rd
@@ -30,10 +30,6 @@ In order for disk-based dependencies to work with static HTML files, it's
 generally necessary to copy them to either the directory of the referencing
 HTML file, or to a subdirectory of that directory. This function makes it
 easier to perform that copy.
-
-If a subdirectory named \emph{name}-\emph{version} already exists in
-\code{outputDir}, then copying is not performed; the existing contents are
-assumed to be up-to-date.
 }
 \seealso{
 \code{\link{makeDependencyRelative}} can be used with the returned


### PR DESCRIPTION
Also changed file.exists() to dir_exists() for the reason described at https://github.com/rstudio/rmarkdown/pull/347