### PR TITLE
Make it possible to suppress dependency version numbers in directory names

### DIFF
--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -193,7 +193,8 @@ urlEncodePath <- function(x) {
 #'
 #' Copies an HTML dependency to a subdirectory of the given directory. The
 #' subdirectory name will be \emph{name}-\emph{version} (for example,
-#' "outputDir/jquery-1.11.0").
+#' "outputDir/jquery-1.11.0"). You may set \code{options(htmltools.dir.version =
+#' FALSE)} to suppress the version number in the subdirectory name.
 #'
 #' In order for disk-based dependencies to work with static HTML files, it's
 #' generally necessary to copy them to either the directory of the referencing
@@ -234,8 +235,10 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
   if (!file.exists(outputDir))
     dir.create(outputDir)
 
-  target_dir <- file.path(outputDir,
-    paste(dependency$name, dependency$version, sep = "-"))
+  target_dir <- if (getOption('htmltools.dir.version', TRUE)) {
+    paste(dependency$name, dependency$version, sep = "-")
+  } else dependency$name
+  target_dir <- file.path(outputDir, target_dir)
 
   if (!file.exists(target_dir)) {
     dir.create(target_dir)

--- a/man/copyDependencyToDir.Rd
+++ b/man/copyDependencyToDir.Rd
@@ -23,7 +23,8 @@ The dependency with its \code{src} value updated to the new
 \description{
 Copies an HTML dependency to a subdirectory of the given directory. The
 subdirectory name will be \emph{name}-\emph{version} (for example,
-"outputDir/jquery-1.11.0").
+"outputDir/jquery-1.11.0"). You may set \code{options(htmltools.dir.version =
+FALSE)} to suppress the version number in the subdirectory name.
 }
 \details{
 In order for disk-based dependencies to work with static HTML files, it's


### PR DESCRIPTION
I often find it more sensible to create the subdirectory without the version number when hosting websites built from R Markdown, because when a dependency library has been updated, e.g. from jquery-1.0 to jquery-2.0, we will have two copies of this library in the target directory. In the past, I was using this ugly hack to remove the version numbers: https://github.com/rstudio/leaflet/blob/c92d6f1d069/compile.R#L7-L19 It will definitely be better if I don't have to hack the HTML output and the dependency directories. This issue and #36 have been my major issues with HTML dependencies. While I was on #36, I thought it would be nice to provide a solution to this one as well. Cc @jjallaire @jcheng5 