### PR TITLE
Allow htmlTemplate() to take text as input. Closes #41

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -5,8 +5,11 @@
 #' \code{html_document}, and can be passed to the function
 #' \code{\link{renderDocument}} to get the final HTML text.
 #'
-#' @param filename Path to an HTML template file.
+#' @param filename Path to an HTML template file. Incompatible with
+#'   \code{text_}.
 #' @param ... Variable values to use when processing the template.
+#' @param text_ A string to use as the template, instead of a file. Incompatible
+#'   with \code{filename}.
 #' @param document_ Is this template a complete HTML document (\code{TRUE}), or
 #'   a fragment of HTML that is to be inserted into an HTML document
 #'   (\code{FALSE})? With \code{"auto"} (the default), auto-detect by searching
@@ -14,9 +17,18 @@
 #'
 #' @seealso \code{\link{renderDocument}}
 #' @export
-htmlTemplate <- function(filename, ..., document_ = "auto") {
-  html <- readChar(filename, file.info(filename)$size, useBytes = TRUE)
-  Encoding(html) <- "UTF-8"
+htmlTemplate <- function(filename = NULL, ..., text_ = NULL, document_ = "auto") {
+  if (!xor(is.null(filename), is.null(text_))) {
+    stop("htmlTemplate requires either `filename` or `text_`.")
+  }
+
+  if (!is.null(filename)) {
+    html <- readChar(filename, file.info(filename)$size, useBytes = TRUE)
+    Encoding(html) <- "UTF-8"
+  } else if(!is.null(text_)) {
+    text_ <- paste(text_, collapse = "\n")
+    html <- enc2utf8(text_)
+  }
 
   pieces <- strsplit(html, "{{", fixed = TRUE)[[1]]
   pieces <- strsplit(pieces, "}}", fixed = TRUE)

--- a/inst/tests/test-template.R
+++ b/inst/tests/test-template.R
@@ -18,6 +18,14 @@ test_that("Code blocks are evaluated and rendered correctly", {
   html <- renderDocument(template)
 
   expect_true(grepl('<div class="foo">bar</div>', html))
+
+  # With text_ argument
+  template <- htmlTemplate(text_ = "a {{ foo + 1 }} b", foo = 10)
+  expect_identical(as.character(as.character(template)), "a \n11\n b")
+
+  # Make char vectors are pasted together
+  template <- htmlTemplate(text_ = c("a", "{{ foo + 1 }} b"), foo = 10)
+  expect_identical(as.character(as.character(template)), "a\n\n11\n b")
 })
 
 test_that("UTF-8 characters in templates", {
@@ -29,6 +37,13 @@ test_that("UTF-8 characters in templates", {
   pat <- rawToChar(as.raw(c(0xce, 0x94, 0xe2, 0x98, 0x85, 0xf0, 0x9f, 0x98, 0x8e)))
   Encoding(pat) <- "UTF-8"
   expect_true(grepl(pat, html))
+
+  # If template is passed text_ argument, make sure it's converted from native
+  # to UTF-8.
+  latin1_str <- rawToChar(as.raw(0xFF))
+  Encoding(latin1_str) <- "latin1"
+  text <- as.character(htmlTemplate(text_ = latin1_str))
+  expect_identical(charToRaw(text), as.raw(c(0xc3, 0xbf)))
 })
 
 

--- a/man/htmlTemplate.Rd
+++ b/man/htmlTemplate.Rd
@@ -4,12 +4,16 @@
 \alias{htmlTemplate}
 \title{Process an HTML template}
 \usage{
-htmlTemplate(filename, ..., document_ = "auto")
+htmlTemplate(filename = NULL, ..., text_ = NULL, document_ = "auto")
 }
 \arguments{
-\item{filename}{Path to an HTML template file.}
+\item{filename}{Path to an HTML template file. Incompatible with
+\code{text_}.}
 
 \item{...}{Variable values to use when processing the template.}
+
+\item{text_}{A string to use as the template, instead of a file. Incompatible
+with \code{filename}.}
 
 \item{document_}{Is this template a complete HTML document (\code{TRUE}), or
 a fragment of HTML that is to be inserted into an HTML document


### PR DESCRIPTION
This adds a `text_` argument to `htmlTemplate()`, so that the template may be a string instead of a file.