### PR TITLE
as.character.shiny.tag returns character. Closes #31

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -180,7 +180,7 @@ format.shiny.tag <- function(x, ..., singletons = character(0), indent = 0) {
 
 #' @export
 as.character.shiny.tag <- function(x, ...) {
-  renderTags(x)$html
+  as.character(renderTags(x)$html)
 }
 
 #' @export


### PR DESCRIPTION
Before this fix:

```
> str(as.character(div("x")))
Classes 'html', 'character'  atomic [1:1] <div>x</div>
  ..- attr(*, "html")= logi TRUE
```


After:

```
> str(as.character(div("x")))
 chr "<div>x</div>"
```