### PR TITLE
Use readChar instead of readLines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,9 @@ htmltools 0.3.3
   suppressed by setting options(htmltools.dir.version = FALSE) when the
   dependency is copied via `copyDependencyToDir()`. (#37)
 
+* Performance improvement rendering tags, by switching from `readLines` to
+  `readChar`.
+
 htmltools 0.3
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR was originally in a commit from #35, but I've pulled it out into a separate PR because it's independent of the other one. It provides a significant speedup because `readLines` is very slow.

Test code, comparing master to this branch:

```R
sizes <- round(runif(1e2, 1000, 100000))
strings <- lapply(sizes, function(size) {
  paste0(
    sample(c(letters, LETTERS), size, replace = TRUE),
    collapse = ""
  )
})

tag <- do.call(div, strings)

system.time({
  as.character(tag)
})

# master:
#    user  system elapsed 
#   0.560   0.000   0.562 

# New code:
#    user  system elapsed 
#   0.176   0.004   0.188 
```