### PR TITLE
More UTF-8 safeguarding

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -526,6 +526,7 @@ doRenderTags <- function(x, indent = 0) {
     },
     finally = close(conn)
   )
+  Encoding(htmlResult) <- "UTF-8"
   return(HTML(htmlResult))
 }
 

--- a/R/template.R
+++ b/R/template.R
@@ -28,11 +28,12 @@ htmlTemplate <- function(filename = NULL, ..., text_ = NULL, document_ = "auto")
     html <- readChar(filename, file.info(filename)$size, useBytes = TRUE)
     Encoding(html) <- "UTF-8"
   } else if(!is.null(text_)) {
-    text_ <- paste(text_, collapse = "\n")
+    text_ <- paste8(text_, collapse = "\n")
     html <- enc2utf8(text_)
   }
 
   pieces <- template_dfa(html)
+  Encoding(pieces) <- "UTF-8"
 
   # Create environment to evaluate code, as a child of the global env. This
   # environment gets the ... arguments assigned as variables.


### PR DESCRIPTION
This fixes the failing tests in test-tags.r and test-template.r on Windows.