### PR TITLE
Use grep/gsub(useBytes = TRUE) for the case locale = C

### DIFF
--- a/R/html_escape.R
+++ b/R/html_escape.R
@@ -34,7 +34,7 @@ htmlEscape <- local({
       .htmlSpecialsPattern
 
     # Short circuit in the common case that there's nothing to escape
-    if (!any(grepl(pattern, text)))
+    if (!any(grepl(pattern, text, useBytes = TRUE)))
       return(text)
 
     specials <- if(attribute)
@@ -43,7 +43,7 @@ htmlEscape <- local({
       .htmlSpecials
 
     for (chr in names(specials)) {
-      text <- gsub(chr, specials[[chr]], text, fixed=TRUE)
+      text <- gsub(chr, specials[[chr]], text, fixed = TRUE, useBytes = TRUE)
     }
 
     return(text)


### PR DESCRIPTION
This fixes the failing tests on Solaris since the locale seems to be C there. I have tested it on Solaris, Windows, OS X, and Ubuntu. I guess it should be a safe change.

FWIW, the root cause was not Solaris but the C locale. You can reproduce the issue on OS X as well:

```
$ LANG=C R
> sessionInfo()
R version 3.2.4 (2016-03-10)
Platform: x86_64-apple-darwin15.3.0 (64-bit)
Running under: OS X 10.11.3 (El Capitan)

locale:
[1] C

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     
> z = rawToChar(as.raw(0xff))
> Encoding(z) = 'latin1'
> z
[1] "<ff>"
> grep('<', z)
[1] 1
> grep('<', z, useBytes = TRUE)
integer(0)
```