### PR TITLE
Allow dependencies to be merged when resolved

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ htmltools 0.3.5
   files under the src directory should be copied when rendering dependencies,
   or only those specified in the dependency objects. (#48)
 
+* `htmlDependency()` gained a new argument `mergeable` to specify whether one
+  dependency can be merged with another of the same name, version, and src, when
+  the dependencies are to be resolved. (#53)
+
 * `copyDependencyToDir()` will always completely overwrite the target directory
   when copying HTML dependency files to make sure all dependency files are
   definitely updated in the target directory when the original dependency

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -23,6 +23,12 @@
 #'   dependency files. If \code{FALSE}, only the files specified in
 #'   \code{script}, \code{stylesheet}, and \code{attachment} are treated as
 #'   dependency files.
+#' @param mergeable Whether multiple dependencies with the same name and the
+#'   highest version can be merged when they are to be resolved via
+#'   \code{\link{resolveDependencies}}: if \code{TRUE}, the components
+#'   \code{meta}, \code{script}, \code{stylesheet}, \code{head}, and
+#'   \code{attachment} will be merged; otherwise only the first dependency is
+#'   kept and the rest are discarded.
 #'
 #' @return An object that can be included in a list of dependencies passed to
 #'   \code{\link{attachDependencies}}.
@@ -67,7 +73,8 @@ htmlDependency <- function(name,
                            stylesheet = NULL,
                            head = NULL,
                            attachment = NULL,
-                           all_files = TRUE) {
+                           all_files = TRUE,
+                           mergeable = FALSE) {
 
   # This function shouldn't be called from a namespace environment with
   # absolute paths.
@@ -99,7 +106,8 @@ htmlDependency <- function(name,
     stylesheet = stylesheet,
     head = head,
     attachment = attachment,
-    all_files = all_files
+    all_files = all_files,
+    mergeable = mergeable
   ))
 }
 

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -97,6 +97,9 @@ htmlDependency <- function(name,
   names(src) <- srcNames
   src <- as.list(src)
 
+  if (length(setdiff(names(meta), "")) != length(meta))
+    stop("'meta' must be a named list")
+
   structure(class = "html_dependency", list(
     name = name,
     version = as.character(version),

--- a/R/tags.R
+++ b/R/tags.R
@@ -106,7 +106,7 @@ mergeDependencies <- function(dependencies) {
       warning("Dependencies that differ in '", i, "' cannot be merged")
       return(dependencies[[1]])
     }
-    for (i in elms) deps[[i]] <- c(deps[[i]], dep[[i]])
+    for (i in elms) deps[i] <- list(c(deps[[i]], dep[[i]]))
   }
   # Remove duplicated elements
   for (i in elms) {

--- a/R/tags.R
+++ b/R/tags.R
@@ -113,8 +113,8 @@ mergeDependencies <- function(dependencies) {
     d <- deps[[i]]
     if (length(d) == 0) next
     deps[[i]] <- if (i != "meta") unique(d) else {
-      # For meta, an element is duplicated only if its name is also duplicated
-      d[!duplicated(d) & !duplicated(names(d))]
+      # For meta, an element is duplicated only if its name is duplicated
+      d[!duplicated(names(d))]
     }
   }
   deps

--- a/man/htmlDependency.Rd
+++ b/man/htmlDependency.Rd
@@ -5,7 +5,8 @@
 \title{Define an HTML dependency}
 \usage{
 htmlDependency(name, version, src, meta = NULL, script = NULL,
-  stylesheet = NULL, head = NULL, attachment = NULL, all_files = TRUE)
+  stylesheet = NULL, head = NULL, attachment = NULL, all_files = TRUE,
+  mergeable = FALSE)
 }
 \arguments{
 \item{name}{Library name}
@@ -34,6 +35,13 @@ Details.}
 dependency files. If \code{FALSE}, only the files specified in
 \code{script}, \code{stylesheet}, and \code{attachment} are treated as
 dependency files.}
+
+\item{mergeable}{Whether multiple dependencies with the same name and the
+highest version can be merged when they are to be resolved via
+\code{\link{resolveDependencies}}: if \code{TRUE}, the components
+\code{meta}, \code{script}, \code{stylesheet}, \code{head}, and
+\code{attachment} will be merged; otherwise only the first dependency is
+kept and the rest are discarded.}
 }
 \value{
 An object that can be included in a list of dependencies passed to

--- a/tests/testthat/test-deps.r
+++ b/tests/testthat/test-deps.r
@@ -26,6 +26,29 @@ test_that("Dependency resolution works", {
   expect_identical(result2, list(b1.0.1, c1.0))
 
   expect_warning(subtractDependencies(result1, list(a1.1)))
+
+  a1 <- htmlDependency(
+    "a", "1", c(href = "/"), meta = list(foo = 1), script = "a1.js",
+    mergeable = TRUE
+  )
+  a2 <- htmlDependency(
+    "a", "1", c(href = "/"), meta = list(foo = 2), script = c("a3.js", "a2.js"),
+    mergeable = TRUE
+  )
+  a3 <- htmlDependency(
+    "a", "1", c(href = "/"), meta = list(bar = 4), script = c("a1.js", "a2.js"),
+    mergeable = TRUE
+  )
+  expect_identical(
+    resolveDependencies(list(a1, a2, a3)), list(htmlDependency(
+      "a", "1", c(href = "/"), meta = list(foo = 1, bar = 4),
+      script = c("a1.js", "a3.js", "a2.js"), mergeable = TRUE
+    ))
+  )
+
+  # Not mergeable
+  a4 <- htmlDependency("a", "1", c(href = "/"), script = "a4.js")
+  expect_identical(resolveDependencies(list(a1, a4)), list(a1))
 })
 
 test_that("Inline dependencies", {


### PR DESCRIPTION
Added a `mergeable` argument to `htmlDependency()`.