### PR TITLE
Print tags as HTML instead of character

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -167,7 +167,7 @@ print.shiny.tag <- function(x, browse = is.browsable(x), ...) {
   if (browse)
     html_print(x)
   else
-    print(as.character(x), ...)
+    print(HTML(as.character(x)), ...)
   invisible(x)
 }
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -214,7 +214,7 @@ print.html <- function(x, ..., browse = is.browsable(x)) {
   if (browse)
     html_print(HTML(x))
   else
-    cat(x, "\n")
+    cat(x, "\n", sep = "")
   invisible(x)
 }
 

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -666,3 +666,10 @@ test_that("Latin1 and system encoding are converted to UTF-8", {
   expect_identical(Encoding(format(HTML(latin1_str))), "UTF-8")
   expect_identical(Encoding(format(tagList(latin1_str))), "UTF-8")
 })
+
+test_that("Printing tags works", {
+  expect_identical(
+    capture.output(print(tags$a(href = "#", "link"))),
+    '<a href="#">link</a>'
+  )
+})


### PR DESCRIPTION
This is an issue introduced by #44.

For example, `tags$a(href = "#", "link")` should be printed as

```html
<a href="#">link</a>
```

instead of

```
[1] "<a href=\"#\">link</a>"
```