### PR TITLE
Create the destination dir if not exist

### DIFF
--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -303,6 +303,8 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
   destfiles <- ifelse(isdir, dirname(destfiles), destfiles)
 
   mapply(function(from, to, isdir) {
+    if (!dir_exists(dirname(to)))
+      dir.create(dirname(to), recursive = TRUE)
     if (isdir && !dir_exists(to))
       dir.create(to)
     file.copy(from, to, overwrite = TRUE, recursive = isdir)


### PR DESCRIPTION
When `all_files = FALSE`, the src files could contain a dir name, e.g., `foo/bar.js`, in which case we cannot copy `src/foo/bar.js` to `dest/foo/bar.js` if `dest/foo/` does not exist, and we need to create this dir before `bar.js` can be copied.

@jcheng5 This issue needs to be fixed before the CRAN release. Thanks!