### PR TITLE
Add viewport units (vw, vh, vmin, vmax) as valid CSS units

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -1380,7 +1380,7 @@ validateCssUnit <- function(x) {
     x <- as.numeric(x)
 
   pattern <-
-    "^(auto|inherit|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|em|ex|pt|pc|px|vh))$"
+    "^(auto|inherit|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|em|ex|pt|pc|px|vh|vw|vmin|vmax))$"
 
   if (is.character(x) &&
       !grepl(pattern, x)) {

--- a/R/tags.R
+++ b/R/tags.R
@@ -1380,7 +1380,7 @@ validateCssUnit <- function(x) {
     x <- as.numeric(x)
 
   pattern <-
-    "^(auto|inherit|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|em|ex|pt|pc|px))$"
+    "^(auto|inherit|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|em|ex|pt|pc|px|vh))$"
 
   if (is.character(x) &&
       !grepl(pattern, x)) {

--- a/R/tags.R
+++ b/R/tags.R
@@ -1354,8 +1354,9 @@ is.singleton <- function(x) {
 #' Single element character vectors must be \code{"auto"} or \code{"inherit"},
 #' or a number. If the number has a suffix, it must be valid: \code{px},
 #' \code{\%}, \code{em}, \code{pt}, \code{in}, \code{cm}, \code{mm}, \code{ex},
-#' or \code{pc}. If the number has no suffix, the suffix \code{"px"} is
-#' appended.
+#' \code{pc}, \code{vh}, \code{vw}, \code{vmin}, or \code{vmax}. 
+#' If the number has no suffix, the suffix \code{"px"} is appended.
+#' 
 #'
 #' Any other value will cause an error to be thrown.
 #'


### PR DESCRIPTION
For specifying the dimensions (especially the height) of figures in Shiny apps it's very useful to access the viewport height. Specifying the height as pixels is too restrictive, and as percent is insufficient: the surrounding `div` may have a small size, and will not increase its size to the height of the browser window. Luckily, there are the viewport-based CSS units, which should pass validation. 

Sources: http://stackoverflow.com/questions/1575141/make-div-100-height-of-browser-window http://caniuse.com/#feat=viewport-units