### PR TITLE
Only tagify once

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -472,7 +472,7 @@ renderTags <- function(x, singletons = character(0), indent = 0) {
   # Do singleton and head processing before rendering
   singletonInfo <- takeSingletons(x, singletons)
   headInfo <- takeHeads(singletonInfo$ui)
-  deps <- resolveDependencies(findDependencies(singletonInfo$ui))
+  deps <- resolveDependencies(findDependencies(singletonInfo$ui, tagify = FALSE))
 
   headIndent <- if (is.numeric(indent)) indent + 1 else indent
   headHtml <- doRenderTags(headInfo$head, indent = headIndent)
@@ -636,12 +636,16 @@ takeHeads <- function(ui) {
 #' Walks a hierarchy of tags looking for attached dependencies.
 #'
 #' @param tags A tag-like object to search for dependencies.
+#' @param tagify Whether to tagify the input before searching for dependencies.
 #'
 #' @return A list of \code{\link{htmlDependency}} objects.
 #'
 #' @export
-findDependencies <- function(tags) {
-  dep <- htmlDependencies(tagify(tags))
+findDependencies <- function(tags, tagify = TRUE) {
+  if (isTRUE(tagify)) {
+    tags <- tagify(tags)
+  }
+  dep <- htmlDependencies(tags)
   if (!is.null(dep) && inherits(dep, "html_dependency"))
     dep <- list(dep)
   children <- if (is.list(tags)) {
@@ -651,7 +655,7 @@ findDependencies <- function(tags) {
       tags
     }
   }
-  childDeps <- unlist(lapply(children, findDependencies), recursive = FALSE)
+  childDeps <- unlist(lapply(children, findDependencies, tagify = FALSE), recursive = FALSE)
   c(childDeps, if (!is.null(dep)) dep)
 }
 
@@ -1160,7 +1164,7 @@ NULL
 knit_print.shiny.tag <- function(x, ...) {
   x <- tagify(x)
   output <- surroundSingletons(x)
-  deps <- resolveDependencies(findDependencies(x))
+  deps <- resolveDependencies(findDependencies(x, tagify = FALSE))
   content <- takeHeads(output)
   head_content <- doRenderTags(tagList(content$head))
 
@@ -1177,7 +1181,7 @@ knit_print.shiny.tag <- function(x, ...) {
 #' @rdname knitr_methods
 #' @export
 knit_print.html <- function(x, ...) {
-  deps <- resolveDependencies(findDependencies(x))
+  deps <- resolveDependencies(findDependencies(x, tagify = FALSE))
   knitr::asis_output(htmlPreserve(as.character(x)),
     meta = if (length(deps)) list(deps))
 }

--- a/man/findDependencies.Rd
+++ b/man/findDependencies.Rd
@@ -4,10 +4,12 @@
 \alias{findDependencies}
 \title{Collect attached dependencies from HTML tag object}
 \usage{
-findDependencies(tags)
+findDependencies(tags, tagify = TRUE)
 }
 \arguments{
 \item{tags}{A tag-like object to search for dependencies.}
+
+\item{tagify}{Whether to tagify the input before searching for dependencies.}
 }
 \value{
 A list of \code{\link{htmlDependency}} objects.


### PR DESCRIPTION
Currently we run tagify within every call to `findDependencies()`. Tagify itself is recursive and runs on every child in the input list. The result is we do a lot of duplicated work trying to re-tagify children that have already been tagified. This ends up being where the vast majority of the time is spent in `renderTags()`. In addition before most of the calls to `findDependencies()` we already tagify the input prior to the call.

This PR adds a `tagify` parameter to `findDependencies()` which will only run tagify once if needed and turns it off in calls where the input is already tagified.

This results in a large speedup for rendering tags, here is a real world example from generating a static report for covr I have been working on.

```r
# devtools::install_github("jimhester/covr")
library(covr)
# Assumes the htmltools directory has the htmltools source code
cov <- package_coverage("htmltools")

# Old timings
# devtools::install_github("rstudio/htmltools")
system.time(shine(cov))
#>  user  system elapsed
#> 8.575   0.038   8.622

# New timings
# devtools::install_github("jimhester/htmltools@tagify")
system.time(shine(cov))
#>  user  system elapsed
#> 3.774   0.028   3.810
```

I am not very familiar with the htmltools codebase, so it is possible I am making an invalid assumption with this, if so please let me know!