### PR TITLE
Add a package argument to htmlDependency()

### DIFF
--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -19,6 +19,9 @@
 #' @param head Arbitrary lines of HTML to insert into the document head
 #' @param attachment Attachment(s) to include within the document head. See
 #'   Details.
+#' @param package An R package name to indicate where to find the \code{src}
+#'   directory when \code{src} is a relative path (see
+#'   \code{\link{resolveDependencies}}).
 #' @param all_files Whether all files under the \code{src} directory are
 #'   dependency files. If \code{FALSE}, only the files specified in
 #'   \code{script}, \code{stylesheet}, and \code{attachment} are treated as

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -67,6 +67,7 @@ htmlDependency <- function(name,
                            stylesheet = NULL,
                            head = NULL,
                            attachment = NULL,
+                           package = NULL,
                            all_files = TRUE) {
 
   # This function shouldn't be called from a namespace environment with
@@ -99,6 +100,7 @@ htmlDependency <- function(name,
     stylesheet = stylesheet,
     head = head,
     attachment = attachment,
+    package = package,
     all_files = all_files
   ))
 }
@@ -270,6 +272,9 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
       return(dependency)
     }
   }
+  # resolve the relative file path to absolute path in package
+  if (!is.null(dependency$package))
+    dir <- system.file(dir, package = dependency$package)
 
   if (length(outputDir) != 1 || outputDir %in% c("", "/"))
     stop('outputDir must be of length 1 and cannot be "" or "/"')

--- a/R/tags.R
+++ b/R/tags.R
@@ -68,11 +68,14 @@ depListToNamedDepList <- function(dependencies) {
 #' the latest version number is used.
 #'
 #' @param dependencies A list of \code{\link{htmlDependency}} objects.
+#' @param resolvePackageDir Whether to resolve the relative path to an absolute
+#'   path via \code{\link{system.file}} when the \code{package} attribute is
+#'   present in a dependency object.
 #' @return dependencies A list of \code{\link{htmlDependency}} objects with
 #'   redundancies removed.
 #'
 #' @export
-resolveDependencies <- function(dependencies) {
+resolveDependencies <- function(dependencies, resolvePackageDir = TRUE) {
   # Remove nulls
   deps <- dependencies[!sapply(dependencies, is.null)]
 
@@ -88,7 +91,13 @@ resolveDependencies <- function(dependencies) {
     sorted <- order(ifelse(depnames == depname, TRUE, NA), depvers,
       na.last = NA, decreasing = TRUE)
     # The first element in the list is the one with the largest version.
-    deps[[sorted[[1]]]]
+    dep <- deps[[sorted[[1]]]]
+    if (resolvePackageDir && !is.null(dep$package)) {
+      dir <- dep$src$file
+      if (!is.null(dir)) dep$src$file <- system.file(dir, package = dep$package)
+      dep$package <- NULL
+    }
+    dep
   }))
 }
 
@@ -1160,7 +1169,7 @@ NULL
 knit_print.shiny.tag <- function(x, ...) {
   x <- tagify(x)
   output <- surroundSingletons(x)
-  deps <- resolveDependencies(findDependencies(x))
+  deps <- resolveDependencies(findDependencies(x), resolvePackageDir = FALSE)
   content <- takeHeads(output)
   head_content <- doRenderTags(tagList(content$head))
 

--- a/man/htmlDependency.Rd
+++ b/man/htmlDependency.Rd
@@ -5,7 +5,8 @@
 \title{Define an HTML dependency}
 \usage{
 htmlDependency(name, version, src, meta = NULL, script = NULL,
-  stylesheet = NULL, head = NULL, attachment = NULL, all_files = TRUE)
+  stylesheet = NULL, head = NULL, attachment = NULL, package = NULL,
+  all_files = TRUE)
 }
 \arguments{
 \item{name}{Library name}
@@ -29,6 +30,10 @@ specified relative to the \code{src} parameter).}
 
 \item{attachment}{Attachment(s) to include within the document head. See
 Details.}
+
+\item{package}{An R package name to indicate where to find the \code{src}
+directory when \code{src} is a relative path (see
+\code{\link{resolveDependencies}}).}
 
 \item{all_files}{Whether all files under the \code{src} directory are
 dependency files. If \code{FALSE}, only the files specified in

--- a/man/resolveDependencies.Rd
+++ b/man/resolveDependencies.Rd
@@ -4,10 +4,14 @@
 \alias{resolveDependencies}
 \title{Resolve a list of dependencies}
 \usage{
-resolveDependencies(dependencies)
+resolveDependencies(dependencies, resolvePackageDir = TRUE)
 }
 \arguments{
 \item{dependencies}{A list of \code{\link{htmlDependency}} objects.}
+
+\item{resolvePackageDir}{Whether to resolve the relative path to an absolute
+path via \code{\link{system.file}} when the \code{package} attribute is
+present in a dependency object.}
 }
 \value{
 dependencies A list of \code{\link{htmlDependency}} objects with


### PR DESCRIPTION
As mentioned in #59, I think it will be nice to provide a `package` argument in htmlDependency() so that `src` is resolved to absolute paths later. One benefit of this is that knitr can cache the dependencies without having to store absolute paths.