### PR TITLE
Make sure the HTML is correctly encoded after restoring chunks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,9 @@
 
 * `validateCssUnit()` now accepts viewport units (vw, vh, vmin, vmax). (#56)
 
+* `restorePreserveChunks()` marks the output with the correct encoding now
+  (UTF-8).
+
 htmltools 0.3.5
 --------------------------------------------------------------------------------
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -1140,8 +1140,11 @@ extractPreserveChunks <- function(strval) {
 #' @rdname htmlPreserve
 #' @export
 restorePreserveChunks <- function(strval, chunks) {
+  strval <- enc2utf8(strval)
+  chunks <- enc2utf8(chunks)
   for (id in names(chunks))
     strval <- gsub(id, chunks[[id]], strval, fixed = TRUE, useBytes = TRUE)
+  Encoding(strval) <- 'UTF-8'
   strval
 }
 


### PR DESCRIPTION
This fixes rstudio/rmarkdown#686 and rstudio/bookdown#142. The problem in these cases is that `chunks` is encoded in UTF-8 and contains multibyte characters, but `strval`'s encoding is unknown (native). After `gsub(useBytes = TRUE)`, `strval`'s encoding is still unknown, and on Windows, unknown/native != UTF-8, so when the restored HTML is written out, the multibyte characters are garbled.

@jcheng5 I think this fix is important, and it will be great if we can make a new CRAN release after merging it.