### PR TITLE
Drop attributes that are length-0 vectors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@
 * `restorePreserveChunks()` marks the output with the correct encoding now
   (UTF-8).
 
+* Length-0 attributes are now dropped, like NULLs. (#65)
+
 htmltools 0.3.5
 --------------------------------------------------------------------------------
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -159,7 +159,7 @@ dropNulls <- function(x) {
 }
 
 nullOrEmpty <- function(x) {
-  is.null(x) || length(x) == 0
+  length(x) == 0
 }
 # Given a vector or list, drop all the NULL items in it
 dropNullsOrEmpty <- function(x) {

--- a/R/tags.R
+++ b/R/tags.R
@@ -161,7 +161,8 @@ dropNulls <- function(x) {
 nullOrEmpty <- function(x) {
   length(x) == 0
 }
-# Given a vector or list, drop all the NULL items in it
+
+# Given a vector or list, drop all the NULL or length-0 items in it
 dropNullsOrEmpty <- function(x) {
   x[!vapply(x, nullOrEmpty, FUN.VALUE=logical(1))]
 }
@@ -342,9 +343,9 @@ tag <- function(`_tag_name`, varArgs) {
   if (is.null(varArgsNames))
     varArgsNames <- character(length=length(varArgs))
 
-  # Named arguments become attribs, dropping NULL values
+  # Named arguments become attribs, dropping NULL and length-0 values
   named_idx <- nzchar(varArgsNames)
-  attribs <- dropNulls(varArgs[named_idx])
+  attribs <- dropNullsOrEmpty(varArgs[named_idx])
 
   # Unnamed arguments are flattened and added as children.
   # Use unname() to remove the names attribute from the list, which would

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -602,7 +602,7 @@ test_that("cssList tests", {
   expect_error(css(1, b=2))
 
   # NULL and empty string are dropped
-  expect_identical(css(a="", b = NULL, "c!" = NULL), "")
+  expect_identical(css(a="", b = NULL, "c!" = NULL, d = character()), "")
 
   # We are dumb about duplicated properties. Probably don't do that.
   expect_identical(css(a=1, a=2), "a:1;a:2;")

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -168,9 +168,21 @@ test_that("Creating simple tags", {
     div(b = "value")
   )
 
+  # length-0 attributes are dropped
+  expect_identical(
+    div(a = character(), b = "value"),
+    div(b = "value")
+  )
+
   # NULL children are dropped
   expect_identical(
     renderTags(div("foo", NULL, list(NULL, list(NULL, "bar"))))$html,
+    renderTags(div("foo", "bar"))$html
+  )
+
+  # length-0 children are dropped
+  expect_identical(
+    renderTags(div("foo", character(), list(character(), list(list(), "bar"))))$html,
     renderTags(div("foo", "bar"))$html
   )
 


### PR DESCRIPTION
This fixes #65.