### PR TITLE
Ensure dependencies are writeable

### DIFF
--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -315,7 +315,7 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
       dir.create(dirname(to), recursive = TRUE)
     if (isdir && !dir_exists(to))
       dir.create(to)
-    file.copy(from, to, overwrite = TRUE, recursive = isdir)
+    file.copy(from, to, overwrite = TRUE, recursive = isdir, copy.mode = FALSE)
   }, srcfiles, destfiles, isdir)
 
   dependency$src$file <- normalizePath(target_dir, "/", TRUE)


### PR DESCRIPTION
Rmarkdown copies dependencies to a temporary directory and tries to remove the directory afterwards.  When a dependency's file mode was set to 444 at package installation (as is the case on Guix), the copied file cannot be removed by R.

Setting `copy.mode` to `FALSE` ensures that the files can be removed by the user (or by the same R process at a later point).
