### PR TITLE
experiment for JSX

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -395,7 +395,13 @@ tagWrite <- function(tag, textWriter, indent=0, eol = "\n") {
   textWriter(paste8(indentText, "<", tag$name, sep=""))
 
   # Convert all attribs to chars explicitly; prevents us from messing up factors
-  attribs <- lapply(tag$attribs, as.character)
+  attribs <- lapply(tag$attribs, function(x){
+    if(inherits(x, c("AsIs","noquote"))){
+      x
+    } else {
+      as.character(x)
+    }
+  })
   # concatenate attributes
   # split() is very slow, so avoid it if possible
   if (anyDuplicated(names(attribs)))
@@ -404,11 +410,14 @@ tagWrite <- function(tag, textWriter, indent=0, eol = "\n") {
   # write attributes
   for (attrib in names(attribs)) {
     attribValue <- attribs[[attrib]]
-    if (!is.na(attribValue)) {
+    if (!is.na(attribValue) && !inherits(attribValue,c("AsIs","noquote"))) {
       if (is.logical(attribValue))
         attribValue <- tolower(attribValue)
       text <- htmlEscape(attribValue, attribute=TRUE)
       textWriter(paste8(" ", attrib,"=\"", text, "\"", sep=""))
+    }
+    else if(inherits(attribValue,c("AsIs","noquote"))){
+      textWriter(paste8(" ", attrib, "=", attribValue, sep="") )
     }
     else {
       textWriter(paste8(" ", attrib, sep=""))


### PR DESCRIPTION
This pull is solely intended as a point of discussion.  It would be really nice (but probably an edge case) to be able to produce `JSX`.  In `JSX` attributes are often unquoted JavaScript.  To achieve this in a naive way with ugly code, I made the changes in this pull.  I am willing to work much harder on this, but I want to make sure it is acceptable before I expend the effort.

### Example

I am working on the [`reactR`](https://github.com/timelyportfolio/reactR) package that would ease working with `React`/`JSX` in R.  As I was experimenting, since `tags` does not allow unquoted attributes, I currently have to do something like [this](https://github.com/timelyportfolio/react-micro-bar-chart/blob/master/code.R).

```
library(htmltools)
library(reactR)

attachDependencies(
  browsable(
    tagList(
      tags$head(tags$script(src="//d3js.org/d3.v3.min.js")),
      tags$body(tags$script(babel_transform(
'
ReactDOM.render(
  <MicroBarChart data={[1,5,2,4]} hoverColor="rgb(161,130,214)"
  fillColor="rgb(210,193,237)" />,
  document.body
)
'
      )))
    )
  ),
  list(
    html_dependency_react(),
    htmlDependency(
      name="microbarchart",
      version="0.1",
      src=file.path(getwd(),"src"),
      script="react-micro-bar-chart.js"
    )
  )
)
```

It would be really nice since I am so spoiled by `htmltools` to do this instead.

```
htmltools::tag("MicroBarChart", list(data=noquote('{[1,5,2,4]}'), hoverColor="rgb(161,130,214)", fillColor="rgb(210,193,237)"))
```

which after this pull gives us.

```
<MicroBarChart data={[1,5,2,4]} hoverColor="rgb(161,130,214)" fillColor="rgb(210,193,237)"></MicroBarChart>
```