### PR TITLE
`as.character.shiny.tags()` will handle non-ASCII attributes correctly

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,9 @@ htmltools 0.3.6.9000
 
 * Updated RcppExports for new version of Rcpp. (#93)
 
+* `as.character.shiny.tags()` will handle non-ASCII attributes correctly if they
+  are not encoded in native encoding.
+
 htmltools 0.3.6
 --------------------------------------------------------------------------------
 

--- a/R/html_escape.R
+++ b/R/html_escape.R
@@ -33,6 +33,7 @@ htmlEscape <- local({
     else
       .htmlSpecialsPattern
 
+    text <- enc2utf8(text)
     # Short circuit in the common case that there's nothing to escape
     if (!any(grepl(pattern, text, useBytes = TRUE)))
       return(text)
@@ -45,6 +46,7 @@ htmlEscape <- local({
     for (chr in names(specials)) {
       text <- gsub(chr, specials[[chr]], text, fixed = TRUE, useBytes = TRUE)
     }
+    Encoding(text) <- "UTF-8"
 
     return(text)
   }

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -681,9 +681,15 @@ test_that("Latin1 and system encoding are converted to UTF-8", {
   # ensure the latin1 attribute returns correctly after escaping
   latin1_str2 <- rawToChar(as.raw(c(0xff, 0x0d, 0x0a)))
   Encoding(latin1_str2) <- "latin1"
+  spanLatin <- as.character(tags$span(latin1_str2, title = latin1_str2))
+  expect_identical(Encoding(spanLatin), "UTF-8")
   expect_identical(
-    as.character(tags$span(latin1_str2, title = latin1_str2)),
-    "<span title=\"\u00ff&#13;&#10;\">\u00ff\r\n</span>"
+    charToRaw(spanLatin),
+    as.raw(c(0x3c, 0x73, 0x70, 0x61, 0x6e, 0x20, 0x74, 0x69, 0x74,
+             0x6c, 0x65, 0x3d, 0x22, 0xc3, 0xbf, 0x26, 0x23, 0x31, 0x33, 0x3b,
+             0x26, 0x23, 0x31, 0x30, 0x3b, 0x22, 0x3e, 0xc3, 0xbf, 0x0d, 0x0a,
+             0x3c, 0x2f, 0x73, 0x70, 0x61, 0x6e, 0x3e
+    ))
   )
 })
 

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -677,6 +677,14 @@ test_that("Latin1 and system encoding are converted to UTF-8", {
 
   expect_identical(Encoding(format(HTML(latin1_str))), "UTF-8")
   expect_identical(Encoding(format(tagList(latin1_str))), "UTF-8")
+
+  # ensure the latin1 attribute returns correctly after escaping
+  latin1_str2 <- rawToChar(as.raw(c(0xff, 0x0d, 0x0a)))
+  Encoding(latin1_str2) <- "latin1"
+  expect_identical(
+    as.character(tags$span(latin1_str2, title = latin1_str2)),
+    "<span title=\"\u00ff&#13;&#10;\">\u00ff\r\n</span>"
+  )
 })
 
 test_that("Printing tags works", {


### PR DESCRIPTION
## Description

- `as.character.shiny.tags()` will handle non-ASCII attributes correctly if they are not encoded in native encoding.
- It's especially problematic on Windows when you need to use non-ASCII strings as the attributes but the strings are encoded in UTF-8.


## Example (notice the string behind `<span title=`)

### Before this PR

```r
library(htmltools)
latin1_str2 <- rawToChar(as.raw(c(255, 13, 10)))
Encoding(latin1_str2) <- "latin1"
as.character(tags$span(latin1_str2, title = latin1_str2))
#> [1] "<span title=\"<ff>&#13;&#10;\">ÿ\r\n</span>"
```

### After this PR

```r
library(htmltools)
latin1_str2 <- rawToChar(as.raw(c(255, 13, 10)))
Encoding(latin1_str2) <- "latin1"
as.character(tags$span(latin1_str2, title = latin1_str2))
#> [1] "<span title=\"ÿ&#13;&#10;\">ÿ\r\n</span>"
```