### PR TITLE
htmlEscape() should coerce inputs to characters

### DIFF
--- a/R/html_escape.R
+++ b/R/html_escape.R
@@ -33,7 +33,7 @@ htmlEscape <- local({
     else
       .htmlSpecialsPattern
 
-    text <- enc2utf8(text)
+    text <- enc2utf8(as.character(text))
     # Short circuit in the common case that there's nothing to escape
     if (!any(grepl(pattern, text, useBytes = TRUE)))
       return(text)

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -699,3 +699,11 @@ test_that("Printing tags works", {
     '<a href="#">link</a>'
   )
 })
+
+test_that("htmlEscape will try to coerce inputs to characters", {
+  x <- list(a1 = "b", a2 = list("b1", "b2"))
+  expect_identical(
+    htmlEscape(x),
+    as.character(x)
+  )
+})


### PR DESCRIPTION
It's a patch for the PR #95

## DESCRIPTION

If you install the current dev version of htmltools and run the following code (a little strange because only one of my shiny apps complains about it):

```r
shiny::shinyApp(ui = shiny::fluidPage(shiny::tags$p("abc")), server = function(input, output, session) { })
```

You'll find the below error reported in the browser:

```
Error in enc2utf8(text) : argument is not a character vector
```

## THE CAUSE

I don't know how to track down the root cause but it should result from the call listed below, which is trying to pass a list object to `htmlEscape()`. 

```r
Called from: htmlEscape(dep$meta)
Browse[1]> text
$viewport
[1] "width=device-width, initial-scale=1"
```

## THE FIX

Well , the reason that it works before #95 .. According to `?grepl()` and `?gsub()`, both functions would try to coerce the input to a character vector. So I think this patch makes sense.

> a character vector where matches are sought, or an object which can be coerced by as.character to a character vector. Long vectors are supported

BTW, since it's just a patch for PR #95 , I think no need to add an entry in the NEWS.

Thanks.