### PR TITLE
Un-export knit_print methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.3.6.9001
-Date: 2017-04-26
+Version: 0.3.6.9002
 Author: RStudio, Inc.
 Maintainer: Joe Cheng <joe@rstudio.com>
 Description: Tools for HTML generation and output.

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
-htmltools 0.3.6.9001
+htmltools 0.3.6.9002
 --------------------------------------------------------------------------------
+
+* The `knit_print` methods are explicitly registered as S3 methods when both
+  knitr and htmltools are loaded. This means that neither shiny nor htmltools
+  need to be attached for the `knit_print` methods to work. (#108)
 
 * Updated RcppExports for new version of Rcpp. (#93)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,30 @@
+register_s3_method <- function(pkg, generic, class, fun = NULL) {
+  stopifnot(is.character(pkg), length(pkg) == 1)
+  stopifnot(is.character(generic), length(generic) == 1)
+  stopifnot(is.character(class), length(class) == 1)
+
+  if (is.null(fun)) {
+    fun <- get(paste0(generic, ".", class), envir = parent.frame())
+  } else {
+    stopifnot(is.function(fun))
+  }
+
+  if (pkg %in% loadedNamespaces()) {
+    registerS3method(generic, class, fun, envir = asNamespace(pkg))
+  }
+
+  # Always register hook in case package is later unloaded & reloaded
+  setHook(
+    packageEvent(pkg, "onLoad"),
+    function(...) {
+      registerS3method(generic, class, fun, envir = asNamespace(pkg))
+    }
+  )
+}
+
+
+.onLoad <- function(...) {
+  register_s3_method("knitr", "knit_print", "shiny.tag")
+  register_s3_method("knitr", "knit_print", "html")
+  register_s3_method("knitr", "knit_print", "shiny.tag.list")
+}


### PR DESCRIPTION
This PR un-exports the `knit_print` methods and registers them as S3 methods when both knitr and htmltools are loaded.

With R >=3.5.0, htmltools must be **attached** in order for the methods to work. There's an exception when shiny is attached: because shiny imports and re-exports these methods, they will also work if shiny is attached.

One consequence is that, because htmltools no longer exports these functions, Shiny can't import them. So Shiny will need to be updated to stop doing that.

Note that the CRAN version of Shiny (1.1.0) cannot be installed with this version of htmltools -- Shiny will fail to build because it can't import the `knit_print` methods from htmltools. If this version of htmltools is installed with an existing Shiny 1.1.0 installation, I believe that Shiny will no longer be able to be loaded.