### PR TITLE
Bypassing dependency overwrite

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,9 @@ htmltools 0.3.6.9003
 * The error message for trailing commas in tag functions now provides context
   and useful information. (#109)
 
+* Adds the ability to skip overwriting existing html depedencies in the function copyDependenciesToDir. Intended to be used with
+rmarkdown::render to speed up rendering.
+
 
 htmltools 0.3.6
 --------------------------------------------------------------------------------

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -252,6 +252,7 @@ urlEncodePath <- function(x) {
 #' @param dependency A single HTML dependency object.
 #' @param outputDir The directory in which a subdirectory should be created for
 #'   this dependency.
+#' @param overwrite_dir A logical indicating whether the dependency should be overwritten if it exists, defaults to \code{TRUE}.
 #' @param mustWork If \code{TRUE} and \code{dependency} does not point to a
 #'   directory on disk (but rather a URL location), an error is raised. If
 #'   \code{FALSE} then non-disk dependencies are returned without modification.

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -263,7 +263,7 @@ urlEncodePath <- function(x) {
 #'   value to make the path relative to a specific directory.
 #'
 #' @export
-copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
+copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE, overwrite_dir = TRUE) {
 
   dir <- dependency$src$file
 
@@ -289,6 +289,12 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
     paste(dependency$name, dependency$version, sep = "-")
   } else dependency$name
   target_dir <- file.path(outputDir, target_dir)
+
+  # if overwrite is false check to see if the file already exists
+  if(!overwrite_dir & dir_exists(target_dir)){
+    dependency$src$file <- normalizePath(target_dir, "/", TRUE)
+    return(dependency)
+  }
 
   # completely remove the target dir because we don't want possible leftover
   # files in the target dir, e.g. we may have lib/foo.js last time, and it was


### PR DESCRIPTION
This pull request adds the ability to skip overwriting html dependencies if they already exist in the function copyDependenciesToDir. Intended to be used with rmarkdown::render to speed up rendering by decreasing I/O time.