### PR TITLE
Open file connection with native encoding before writing.

### DIFF
--- a/R/html_print.R
+++ b/R/html_print.R
@@ -98,9 +98,8 @@ save_html <- function(html, file, background = "white", libdir = "lib") {
             "</html>")
 
   # write it
-  file_nat <- file(file, open = "w+", encoding = "native.enc")
-  writeLines(enc2utf8(html), file_nat, useBytes = TRUE)
-  close(file_nat)
+  opts = options(encoding = "native.enc"); on.exit(options(opts), add = TRUE)
+  writeLines(enc2utf8(html), file, useBytes = TRUE)
 }
 
 

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -98,7 +98,9 @@ save_html <- function(html, file, background = "white", libdir = "lib") {
             "</html>")
 
   # write it
-  writeLines(html, file, useBytes = TRUE)
+  file_nat <- file(file, open = "w+", encoding = "native.enc")
+  writeLines(enc2utf8(html), file_nat, useBytes = TRUE)
+  close(file_nat)
 }
 
 

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -98,7 +98,8 @@ save_html <- function(html, file, background = "white", libdir = "lib") {
             "</html>")
 
   # write it
-  opts = options(encoding = "native.enc"); on.exit(options(opts), add = TRUE)
+  opts <- options(encoding = "native.enc")
+  on.exit(options(opts), add = TRUE)
   writeLines(enc2utf8(html), file, useBytes = TRUE)
 }
 


### PR DESCRIPTION
Hi!

Actually this comes when I am trying to convert ggplot plots using `plotly::ggplotly()`. It always issues a warning which comes from `htmltools:::save_html` complaining about invalid character and a blank web page is opened.

```r
getOption("encoding")
#> "UTF-8"

Warning message:
In writeLines(html, file, useBytes = TRUE)  :
    invalid char string in output conversion
```

If I set encoding from `"UTF-8"` to `"native.enc"`, the problem is gone.

As shown in this brilliant blog on [string encoding in R](http://kevinushey.github.io/blog/2018/02/21/string-encoding-and-r/), the safest way to write UTF-8 characters on Windows is manually open the connection with native encoding before writing.

Hope this PR will help. Thanks.