### PR TITLE
Fix for extra linefeeds in CSS/Script includes

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -1370,7 +1370,7 @@ includeCSS <- function(path, ...) {
   if (is.null(args$type))
     args$type <- 'text/css'
   return(do.call(tags$style,
-    c(list(HTML(paste8(lines, collapse='\r\n'))), args)))
+    c(list(HTML(paste8(lines, collapse='\n'))), args)))
 }
 
 #' @rdname include

--- a/R/tags.R
+++ b/R/tags.R
@@ -1377,7 +1377,7 @@ includeCSS <- function(path, ...) {
 #' @export
 includeScript <- function(path, ...) {
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
-  return(tags$script(HTML(paste8(lines, collapse='\r\n')), ...))
+  return(tags$script(HTML(paste8(lines, collapse='\n')), ...))
 }
 
 #' Include content only once


### PR DESCRIPTION
I changed the `collapse=` value from `"\r\n"` to `"\n"` to prevent having empty lines created in the source HTML. 

For instance, before this fix, notice the extra empty lines (which do not reflect the true content of _bootstrap.min.css_)

```
<!DOCTYPE html>
<html>
<head>
<meta charset="utf-8"/>

  <title>Some Title</title>
  <style type="text/css">/*!

 * Bootstrap v4.1.2 (https://getbootstrap.com/)

 * Copyright 2011-2018 The Bootstrap Authors

 * Copyright 2011-2018 Twitter, Inc.

 * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
```

After the fix, all is normal. Tested on both Windows and Linux,

```
<!DOCTYPE html>
<html>
<head>
<meta charset="utf-8"/>

  <title>Some Title</title>
  <style type="text/css">/*!
 * Bootstrap v4.1.2 (https://getbootstrap.com/)
 * Copyright 2011-2018 The Bootstrap Authors
 * Copyright 2011-2018 Twitter, Inc.
 * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
```