### PR TITLE
Add tests for different locales

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Imports:
     Rcpp
 Suggests:
     markdown,
-    testthat
+    testthat,
+    withr
 Enhances: knitr
 License: GPL (>= 2)
 URL: https://github.com/rstudio/htmltools

--- a/R/tags.R
+++ b/R/tags.R
@@ -3,15 +3,16 @@ NULL
 
 # Like base::paste, but converts all string args to UTF-8 first.
 paste8 <- function(..., sep = " ", collapse = NULL) {
-  args <- c(
-    lapply(list(...), enc2utf8),
-    list(
-      sep = if (is.null(sep)) sep else enc2utf8(sep),
-      collapse = if (is.null(collapse)) collapse else enc2utf8(collapse)
-    )
-  )
-
-  do.call(paste, args)
+  # args <- c(
+  #   lapply(list(...), enc2utf8),
+  #   list(
+  #     sep = if (is.null(sep)) sep else enc2utf8(sep),
+  #     collapse = if (is.null(collapse)) collapse else enc2utf8(collapse)
+  #   )
+  # )
+  #
+  # do.call(paste, args)
+  enc2utf8(paste(..., sep=sep, collapse=collapse))
 }
 
 # Reusable function for registering a set of methods with S3 manually. The

--- a/R/tags.R
+++ b/R/tags.R
@@ -3,16 +3,15 @@ NULL
 
 # Like base::paste, but converts all string args to UTF-8 first.
 paste8 <- function(..., sep = " ", collapse = NULL) {
-  # args <- c(
-  #   lapply(list(...), enc2utf8),
-  #   list(
-  #     sep = if (is.null(sep)) sep else enc2utf8(sep),
-  #     collapse = if (is.null(collapse)) collapse else enc2utf8(collapse)
-  #   )
-  # )
-  #
-  # do.call(paste, args)
-  enc2utf8(paste(..., sep=sep, collapse=collapse))
+  args <- c(
+    lapply(list(...), enc2utf8),
+    list(
+      sep = if (is.null(sep)) sep else enc2utf8(sep),
+      collapse = if (is.null(collapse)) collapse else enc2utf8(collapse)
+    )
+  )
+
+  do.call(paste, args)
 }
 
 # Reusable function for registering a set of methods with S3 manually. The

--- a/tests/testthat/helper-locale.R
+++ b/tests/testthat/helper-locale.R
@@ -1,7 +1,7 @@
 is_locale_available <- function(loc){
   set_locale_failed <- FALSE
   tryCatch(
-    Sys.setlocale("LC_ALL", loc),
+    withr::with_locale(c(LC_COLLATE=loc), {}),
     warning = function(e){ set_locale_failed <<- TRUE }
   )
   !set_locale_failed

--- a/tests/testthat/helper-locale.R
+++ b/tests/testthat/helper-locale.R
@@ -1,0 +1,8 @@
+is_locale_available <- function(loc){
+  set_locale_failed <- FALSE
+  tryCatch(
+    Sys.setlocale("LC_ALL", loc),
+    warning = function(e){ set_locale_failed <<- TRUE }
+  )
+  !set_locale_failed
+}

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -729,6 +729,30 @@ test_that("Latin1 and system encoding are converted to UTF-8", {
   )
 })
 
+test_that("paste8 in Chinese locale works", {
+  Sys.setlocale("LC_ALL", "Chinese")
+  x <- "\377"
+  Encoding(x) <- "latin1"
+  expect_identical(x, "ÿ")
+  expect_identical(Encoding(x), "latin1")
+
+  y <- "\U4E2d"  # Using \Uxxxx always is encoded as UTF-8
+  expect_identical(y, "中")
+  expect_identical(Encoding(y), "UTF-8")
+
+  xy <- paste8(x, y)
+  xy
+  expect_identical(xy, "ÿ 中")
+  expect_identical(Encoding(xy), "UTF-8")
+
+  xy <- paste8(c(x, y), collapse = "")
+  expect_identical(xy, "ÿ中")
+  expect_identical(Encoding(xy), "UTF-8")
+
+  # Restore default locale
+  Sys.setlocale("LC_ALL", "")
+})
+
 test_that("Printing tags works", {
   expect_identical(
     capture.output(print(tags$a(href = "#", "link"))),

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -734,20 +734,20 @@ test_that("paste8 in Chinese locale works", {
   withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), {
     x <- "\377"
     Encoding(x) <- "latin1"
-    expect_identical(x, "ÿ")
+    expect_identical(x, "\Uff")
     expect_identical(Encoding(x), "latin1")
 
     y <- "\U4E2d"  # Using \Uxxxx always is encoded as UTF-8
-    expect_identical(y, "中")
+    expect_identical(y, "\U4E2d")
     expect_identical(Encoding(y), "UTF-8")
 
     xy <- paste8(x, y)
     xy
-    expect_identical(xy, "ÿ 中")
+    expect_identical(xy, "\Uff \U4E2d")
     expect_identical(Encoding(xy), "UTF-8")
 
     xy <- paste8(c(x, y), collapse = "")
-    expect_identical(xy, "ÿ中")
+    expect_identical(xy, "\Uff\U4E2d")
     expect_identical(Encoding(xy), "UTF-8")
   })
 })

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -730,27 +730,26 @@ test_that("Latin1 and system encoding are converted to UTF-8", {
 })
 
 test_that("paste8 in Chinese locale works", {
-  Sys.setlocale("LC_ALL", "Chinese")
-  x <- "\377"
-  Encoding(x) <- "latin1"
-  expect_identical(x, "ÿ")
-  expect_identical(Encoding(x), "latin1")
+  loc <- "Chinese"
+  withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), {
+    x <- "\377"
+    Encoding(x) <- "latin1"
+    expect_identical(x, "ÿ")
+    expect_identical(Encoding(x), "latin1")
 
-  y <- "\U4E2d"  # Using \Uxxxx always is encoded as UTF-8
-  expect_identical(y, "中")
-  expect_identical(Encoding(y), "UTF-8")
+    y <- "\U4E2d"  # Using \Uxxxx always is encoded as UTF-8
+    expect_identical(y, "中")
+    expect_identical(Encoding(y), "UTF-8")
 
-  xy <- paste8(x, y)
-  xy
-  expect_identical(xy, "ÿ 中")
-  expect_identical(Encoding(xy), "UTF-8")
+    xy <- paste8(x, y)
+    xy
+    expect_identical(xy, "ÿ 中")
+    expect_identical(Encoding(xy), "UTF-8")
 
-  xy <- paste8(c(x, y), collapse = "")
-  expect_identical(xy, "ÿ中")
-  expect_identical(Encoding(xy), "UTF-8")
-
-  # Restore default locale
-  Sys.setlocale("LC_ALL", "")
+    xy <- paste8(c(x, y), collapse = "")
+    expect_identical(xy, "ÿ中")
+    expect_identical(Encoding(xy), "UTF-8")
+  })
 })
 
 test_that("Printing tags works", {

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -731,6 +731,8 @@ test_that("Latin1 and system encoding are converted to UTF-8", {
 
 test_that("paste8 in Chinese locale works", {
   loc <- "Chinese"
+  testthat::skip_if_not(is_locale_available(loc), "Chinese locale not available")
+
   withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), {
     x <- "\377"
     Encoding(x) <- "latin1"

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -28,31 +28,34 @@ test_that("Code blocks are evaluated and rendered correctly", {
   expect_identical(as.character(as.character(template)), "a\n\n11\n b")
 })
 
-test_that("UTF-8 characters in templates", {
-  test_template <- function(){
-    template <- htmlTemplate("template-document.html", x = "")
-    html <- renderDocument(template)
+test_template <- function(){
+  template <- htmlTemplate("template-document.html", x = "")
+  html <- renderDocument(template)
 
-    # Create the string 'Δ★😎', making sure it's UTF-8 encoded on all platforms.
-    # These characters are 2, 3, and 4 bytes long, respectively.
-    pat <- rawToChar(as.raw(c(0xce, 0x94, 0xe2, 0x98, 0x85, 0xf0, 0x9f, 0x98, 0x8e)))
-    Encoding(pat) <- "UTF-8"
-    expect_true(grepl(pat, html))
+  # Create the string 'Δ★😎', making sure it's UTF-8 encoded on all platforms.
+  # These characters are 2, 3, and 4 bytes long, respectively.
+  pat <- rawToChar(as.raw(c(0xce, 0x94, 0xe2, 0x98, 0x85, 0xf0, 0x9f, 0x98, 0x8e)))
+  Encoding(pat) <- "UTF-8"
+  expect_true(grepl(pat, html))
 
-    # If template is passed text_ argument, make sure it's converted from native
-    # to UTF-8.
-    latin1_str <- rawToChar(as.raw(0xFF))
-    Encoding(latin1_str) <- "latin1"
-    text <- as.character(htmlTemplate(text_ = latin1_str))
-    expect_identical(charToRaw(text), as.raw(c(0xc3, 0xbf)))
-  }
+  # If template is passed text_ argument, make sure it's converted from native
+  # to UTF-8.
+  latin1_str <- rawToChar(as.raw(0xFF))
+  Encoding(latin1_str) <- "latin1"
+  text <- as.character(htmlTemplate(text_ = latin1_str))
+  expect_identical(charToRaw(text), as.raw(c(0xc3, 0xbf)))
+}
 
+test_that("UTF-8 characters in templates with default locale", {
   # The default locale
   loc <- ""
   withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), test_template())
 
+})
+test_that("UTF-8 characters in templates with Chinese locale", {
   # Chinese locale
   loc <- "Chinese"
+  testthat::skip_if_not(is_locale_available(loc), "Chinese locale not available")
   withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), test_template())
 })
 

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -29,21 +29,29 @@ test_that("Code blocks are evaluated and rendered correctly", {
 })
 
 test_that("UTF-8 characters in templates", {
-  template <- htmlTemplate("template-document.html", x = "")
-  html <- renderDocument(template)
+  test_template <- function(locale=""){
+    Sys.setlocale("LC_ALL", locale)
+    template <- htmlTemplate("template-document.html", x = "")
+    html <- renderDocument(template)
 
-  # Create the string 'Δ★😎', making sure it's UTF-8 encoded on all platforms.
-  # These characters are 2, 3, and 4 bytes long, respectively.
-  pat <- rawToChar(as.raw(c(0xce, 0x94, 0xe2, 0x98, 0x85, 0xf0, 0x9f, 0x98, 0x8e)))
-  Encoding(pat) <- "UTF-8"
-  expect_true(grepl(pat, html))
+    # Create the string 'Δ★😎', making sure it's UTF-8 encoded on all platforms.
+    # These characters are 2, 3, and 4 bytes long, respectively.
+    pat <- rawToChar(as.raw(c(0xce, 0x94, 0xe2, 0x98, 0x85, 0xf0, 0x9f, 0x98, 0x8e)))
+    Encoding(pat) <- "UTF-8"
+    expect_true(grepl(pat, html))
 
-  # If template is passed text_ argument, make sure it's converted from native
-  # to UTF-8.
-  latin1_str <- rawToChar(as.raw(0xFF))
-  Encoding(latin1_str) <- "latin1"
-  text <- as.character(htmlTemplate(text_ = latin1_str))
-  expect_identical(charToRaw(text), as.raw(c(0xc3, 0xbf)))
+    # If template is passed text_ argument, make sure it's converted from native
+    # to UTF-8.
+    latin1_str <- rawToChar(as.raw(0xFF))
+    Encoding(latin1_str) <- "latin1"
+    text <- as.character(htmlTemplate(text_ = latin1_str))
+    expect_identical(charToRaw(text), as.raw(c(0xc3, 0xbf)))
+
+    # Restore locale
+    Sys.setlocale("LC_ALL", "")
+  }
+  test_template("") # The default locale
+  test_template("Chinese") # Chinese locale
 })
 
 test_that("UTF-8 characters in template head but not body", {

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -29,8 +29,7 @@ test_that("Code blocks are evaluated and rendered correctly", {
 })
 
 test_that("UTF-8 characters in templates", {
-  test_template <- function(locale=""){
-    Sys.setlocale("LC_ALL", locale)
+  test_template <- function(){
     template <- htmlTemplate("template-document.html", x = "")
     html <- renderDocument(template)
 
@@ -46,12 +45,15 @@ test_that("UTF-8 characters in templates", {
     Encoding(latin1_str) <- "latin1"
     text <- as.character(htmlTemplate(text_ = latin1_str))
     expect_identical(charToRaw(text), as.raw(c(0xc3, 0xbf)))
-
-    # Restore locale
-    Sys.setlocale("LC_ALL", "")
   }
-  test_template("") # The default locale
-  test_template("Chinese") # Chinese locale
+
+  # The default locale
+  loc <- ""
+  withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), test_template())
+
+  # Chinese locale
+  loc <- "Chinese"
+  withr::with_locale(c(LC_COLLATE=loc, LC_CTYPE=loc, LC_MONETARY=loc, LC_TIME=loc), test_template())
 })
 
 test_that("UTF-8 characters in template head but not body", {


### PR DESCRIPTION
(Please review each commit independently.)

Adds tests for different locales and demonstrates that Windows fails in some scenarios (see [AppVeyor results](https://ci.appveyor.com/project/trestletech/htmltools/builds/26189938) on 01fb94b) when using an abbreviated form of `paste8` that was being considered. The form proposed in 01fb94b does improve performance by ~20%, but we'd need additional checks to cover the scenarios that aren't reliably encoded which would make the implementation more fragile and -- perhaps -- not such a performance boost.

```
> test_check("htmltools")
-- 1. Failure: paste8 in Chinese locale works (@test-tags.r#749)  --------------
`xy` not identical to "<U+00FF>÷–".
1/1 mismatches
x[1]: "<ff>÷–"
y[1]: "<U+00FF>÷–"

-- 2. Failure: UTF-8 characters in templates (@test-template.R#54)  ------------
charToRaw(text) not identical to as.raw(c(195, 191)).
Lengths (4, 2) differ (comparison on first 2 components)
2 element mismatches

== testthat results  ===========================================================
OK: 225 SKIPPED: 0 WARNINGS: 0 FAILED: 2
1. Failure: paste8 in Chinese locale works (@test-tags.r#749) 
2. Failure: UTF-8 characters in templates (@test-template.R#54) 

Error: testthat unit tests failed
Execution halted
```

It appears that `paste` behaves differently when given multiple character arguments as parameters versus being given a character vector with elements of different encodings. In the former case, the strings are all converted to UTF-8 (at least if one of the elements is in UTF-8), but in the latter case the behavior isn't what we want.

These tests fail _only_ on Windows -- you'll notice that the Travis tests were happy all along.