### PR TITLE
Add valid css units

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -1438,8 +1438,9 @@ is.singleton <- function(x) {
 #'
 #' Single element character vectors must be \code{"auto"} or \code{"inherit"},
 #' or a number. If the number has a suffix, it must be valid: \code{px},
-#' \code{\%}, \code{em}, \code{pt}, \code{in}, \code{cm}, \code{mm}, \code{ex},
-#' \code{pc}, \code{vh}, \code{vw}, \code{vmin}, or \code{vmax}.
+#' \code{\%}, \code{ch}, \code{em}, \code{rem}, \code{pt}, \code{in}, \code{cm},
+#' \code{mm}, \code{ex}, \code{pc}, \code{vh}, \code{vw}, \code{vmin}, or
+#' \code{vmax}.
 #' If the number has no suffix, the suffix \code{"px"} is appended.
 #'
 #'
@@ -1466,7 +1467,7 @@ validateCssUnit <- function(x) {
     x <- as.numeric(x)
 
   pattern <-
-    "^(auto|inherit|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|em|ex|pt|pc|px|vh|vw|vmin|vmax))$"
+    "^(auto|inherit|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|ch|em|ex|rem|pt|pc|px|vh|vw|vmin|vmax))$"
 
   if (is.character(x) &&
       !grepl(pattern, x)) {


### PR DESCRIPTION
This PR adds valid css units such as `ch` and `rem`.

I'd also want to support `calc()`.
However, regex for fully validating it will be quite complex.
What about just add `calc(.*)` ?
