### PR TITLE
Stop extra carriage returns from being inserted on windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,9 @@ htmltools 0.3.6.9003
 
 * Fixed #125: `print.html` removes html dependencies. (#126)
 
+* Stopped extra carriage returns from being inserted by `save_html` on Windows.
+  (#137)
+
 htmltools 0.3.6
 --------------------------------------------------------------------------------
 

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -98,8 +98,16 @@ save_html <- function(html, file, background = "white", libdir = "lib") {
             "</body>",
             "</html>")
 
+  if (is.character(file)) {
+    # Write to file in binary mode, so \r\n in input doesn't become \r\r\n
+    con <- base::file(file, open = "w+b")
+    on.exit(close(con))
+  } else {
+    con <- file
+  }
+
   # write it
-  writeLines(html, file, useBytes = TRUE)
+  writeLines(html, con, useBytes = TRUE)
 }
 
 

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -69,6 +69,9 @@ html_print <- function(html, background = "white", viewer = getOption("viewer", 
 #'
 #' @export
 save_html <- function(html, file, background = "white", libdir = "lib") {
+  force(html)
+  force(background)
+  force(libdir)
 
   # ensure that the paths to dependencies are relative to the base
   # directory where the webpage is being built.

--- a/R/tags.R
+++ b/R/tags.R
@@ -1076,7 +1076,7 @@ as.tags.html_dependency <- function(x, ...) {
 #'
 #' @export
 htmlPreserve <- function(x) {
-  x <- paste(x, collapse = "\r\n")
+  x <- paste(x, collapse = "\n")
   if (nzchar(x))
     sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x)
   else
@@ -1361,7 +1361,7 @@ hr <- tags$hr
 #' @export
 includeHTML <- function(path) {
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
-  return(HTML(paste8(lines, collapse='\r\n')))
+  return(HTML(paste8(lines, collapse='\n')))
 }
 
 #' @note \code{includeText} escapes its contents, but does no other processing.
@@ -1374,7 +1374,7 @@ includeHTML <- function(path) {
 #' @export
 includeText <- function(path) {
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
-  return(paste8(lines, collapse='\r\n'))
+  return(paste8(lines, collapse='\n'))
 }
 
 #' @note The \code{includeMarkdown} function requires the \code{markdown}
@@ -1396,14 +1396,14 @@ includeCSS <- function(path, ...) {
   if (is.null(args$type))
     args$type <- 'text/css'
   return(do.call(tags$style,
-    c(list(HTML(paste8(lines, collapse='\r\n'))), args)))
+    c(list(HTML(paste8(lines, collapse='\n'))), args)))
 }
 
 #' @rdname include
 #' @export
 includeScript <- function(path, ...) {
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
-  return(tags$script(HTML(paste8(lines, collapse='\r\n')), ...))
+  return(tags$script(HTML(paste8(lines, collapse='\n')), ...))
 }
 
 #' Include content only once

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -17,3 +17,32 @@ test_that("print.html preserves dependencies for HTML()", {
   result_contents <- readLines(url)
   expect_true(any(grepl("http://example.com/test.js", result_contents)))
 })
+
+test_that("CRLF is properly handled", {
+  txt <- paste(c("x", "y", ""), collapse = "\r\n")
+
+  tmp <- tempfile(fileext = ".txt")
+  on.exit(unlink(tmp))
+
+  writeBin(charToRaw(txt), tmp)
+
+  obj <- tagList(
+    includeHTML(tmp),
+    includeCSS(tmp),
+    includeMarkdown(tmp),
+    includeScript(tmp),
+    includeText(tmp),
+    txt,
+    HTML(txt)
+  )
+
+  out <- tempfile(fileext = ".html")
+  on.exit(unlink(out))
+
+  save_html(obj, out)
+
+  chr <- readChar(out, file.size(out))
+  expect_false(grepl("\r\r\n", chr))
+
+  expect_false(grepl("\r\r\n", as.character(obj)))
+})


### PR DESCRIPTION
## Testing notes

Windows only:

Make a file in Windows' Notepad.exe (or other Windows text editor that definitely writes line endings with `\r\n`), put a couple of lines of text in it, save as `test.css`.

In RStudio:

```r
f <- tempfile()
htmltools::save_html(htmltools::includeCSS("test.css"), f)
file.edit(f)
```

You should see that the lines from your `test.css` have what appear to be extra line breaks.