### PR TITLE
add unit test to ensure #117 is fixed

### DIFF
--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -48,11 +48,12 @@ test_that("CRLF is properly handled", {
 })
 
 test_that("Special characters are not re-encoded", {
+  skip_on_cran()
   # https://github.com/rstudio/htmltools/pull/117
   f <- tempfile(fileext = ".html")
   withr::with_options(
     list(encoding = "UTF-8"),
     save_html(div("brûlée"), f)
   )
-  any(grepl("brûlée", readLines(f)))
+  expect_true(any(grepl("brûlée", readLines(f))))
 })

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -46,3 +46,13 @@ test_that("CRLF is properly handled", {
 
   expect_false(grepl("\r\r\n", as.character(obj)))
 })
+
+test_that("Special characters are not re-encoded", {
+  # https://github.com/rstudio/htmltools/pull/117
+  f <- tempfile(fileext = ".html")
+  withr::with_options(
+    list(encoding = "UTF-8"),
+    save_html(div("brûlée"), f)
+  )
+  any(grepl("brûlée", readLines(f)))
+})


### PR DESCRIPTION
The changes in #137 wound up fixing the problem described in #117, so this is just a unit test to ensure the problem is fixed.

Note that, previous to #137, this test would fail on systems where the native encoding is something other than UTF-8