### PR TITLE
Fix accidental working directory change

### DIFF
--- a/R/html_print.R
+++ b/R/html_print.R
@@ -104,7 +104,7 @@ save_html <- function(html, file, background = "white", libdir = "lib") {
   if (is.character(file)) {
     # Write to file in binary mode, so \r\n in input doesn't become \r\r\n
     con <- base::file(file, open = "w+b")
-    on.exit(close(con))
+    on.exit(close(con), add = TRUE)
   } else {
     con <- file
   }

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -8,7 +8,7 @@ test_that("print.html preserves dependencies for HTML()", {
   op <- options(viewer = function(url) {
     url <<- url
   })
-  on.exit(options(op))
+  on.exit(options(op), add = TRUE)
 
   print(attachDependencies(HTML("test"),
     list(dep)
@@ -22,7 +22,7 @@ test_that("CRLF is properly handled", {
   txt <- paste(c("x", "y", ""), collapse = "\r\n")
 
   tmp <- tempfile(fileext = ".txt")
-  on.exit(unlink(tmp))
+  on.exit(unlink(tmp), add = TRUE)
 
   writeBin(charToRaw(txt), tmp)
 
@@ -37,9 +37,12 @@ test_that("CRLF is properly handled", {
   )
 
   out <- tempfile(fileext = ".html")
-  on.exit(unlink(out))
+  on.exit(unlink(out), add = TRUE)
 
+  wd <- getwd()
   save_html(obj, out)
+  # Verify that save_html doesn't alter working dir
+  expect_identical(getwd(), wd)
 
   chr <- readChar(out, file.size(out))
   expect_false(grepl("\r\r\n", chr))

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -56,7 +56,9 @@ test_that("Special characters are not re-encoded", {
   f <- tempfile(fileext = ".html")
   withr::with_options(
     list(encoding = "UTF-8"),
-    save_html(div("brûlée"), f)
+    {
+      save_html(div("brûlée"), f)
+      expect_true(any(grepl("brûlée", readLines(f))))
+    }
   )
-  expect_true(any(grepl("brûlée", readLines(f))))
 })


### PR DESCRIPTION
Previously, calling `save_html` would change the current directory to a random temp dir. This was due to the introduction of a new `on.exit()` call that didn't have `add = TRUE`. 😬 

## Testing notes

```r
writeChar("line 1\r\nline 2\r\nline 3\r\n", "test.css")
css <- htmltools::includeCSS("test.css")
f <- tempfile()
htmltools::save_html(css, f)
```

The repro is if the last line (`save_html`) causes the working directory to change (you can see this at the top of the Console tab, or call `getwd()`).