### PR TITLE
should specify `perl=TRUE` in order to handle emoji strings on Windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ htmltools 0.4.0.9001
 * Added `capturePlot` and `plotTag` functions, for easily creating image files
   and HTML <img> tags (respectively) from plot expressions.
 
+* Fixed #156: Now `extractPreserveChunks()` handles strings contain Emoji Unicode strings correctly on Windows. (#157)
+
 htmltools 0.4.0
 --------------------------------------------------------------------------------
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -1167,7 +1167,7 @@ extractPreserveChunks <- function(strval) {
     strval <- paste(strval, collapse = "\n")
 
   # matches contains the index of all the start and end markers
-  matches <- gregexpr(pattern, strval)[[1]]
+  matches <- gregexpr(pattern, strval, perl = TRUE)[[1]]
   lengths <- attr(matches, "match.length", TRUE)
 
   # No markers? Just return.

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -852,3 +852,12 @@ test_that("trailing commas allowed everywhere", {
     css(style = "",)
   })
 })
+
+test_that("extractPreserveChunks works for emoji strings", {
+  x <- "<!--html_preserve-->chunck1<!--/html_preserve-->\U0001F937<!--html_preserve-->chunck2<!--/html_preserve-->"
+  out <- extractPreserveChunks(x)
+  expect_equivalent(
+    out$chunks,
+    c('chunck2', 'chunck1')
+  )
+})


### PR DESCRIPTION
Closes #156 
Closes rstudio/DT#661