### PR TITLE
Support "inside" argument value for .noWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,9 @@ htmltools 0.4.0.9001
 
 * Fixed #156: Now `extractPreserveChunks()` handles strings contain Emoji Unicode strings correctly on Windows. (#157)
 
+* The `.noWS` parameter for suppressing whitespace can now take an `"inside"`
+  value (equivalent to `c("after-start", "before-end")`). (#163)
+
 htmltools 0.4.0
 --------------------------------------------------------------------------------
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -387,7 +387,7 @@ isTagList <- function(x) {
   is.list(x) && (inherits(x, "shiny.tag.list") || identical(class(x), "list"))
 }
 
-noWSOptions <- c("before", "after", "after-begin", "before-end", "outside")
+noWSOptions <- c("before", "after", "after-begin", "before-end", "outside", "inside")
 # Ensure that the provided `.noWS` string contains only valid options
 validateNoWS <- function(.noWS){
   if (!all(.noWS %in% noWSOptions)){
@@ -724,8 +724,9 @@ findDependencies <- function(tags, tagify = TRUE) {
 #'   attributes, use a named argument with a \code{NA} value. (see example)
 #' @param .noWS A character vector used to omit some of the whitespace that
 #'   would normally be written around this tag. Valid options include
-#'   \code{before}, \code{after}, \code{outside}, \code{after-begin}, and
-#'   \code{before-end}. Any number of these options can be specified.
+#'   \code{before}, \code{after}, \code{outside}, \code{after-begin},
+#'   \code{before-end}, and \code{inside}. Any number of these options can be
+#'   specified.
 #' @references \itemize{
 #'    \item W3C html specification about boolean attributes
 #'    \url{https://www.w3.org/TR/html5/infrastructure.html#sec-boolean-attributes}

--- a/man/builder.Rd
+++ b/man/builder.Rd
@@ -68,8 +68,9 @@ attributes, use a named argument with a \code{NA} value. (see example)}
 
 \item{.noWS}{A character vector used to omit some of the whitespace that
 would normally be written around this tag. Valid options include
-\code{before}, \code{after}, \code{outside}, \code{after-begin}, and
-\code{before-end}. Any number of these options can be specified.}
+\code{before}, \code{after}, \code{outside}, \code{after-begin},
+\code{before-end}, and \code{inside}. Any number of these options can be
+specified.}
 }
 \description{
 Simple functions for constructing HTML documents.

--- a/tests/testthat/test-whitespace.r
+++ b/tests/testthat/test-whitespace.r
@@ -99,6 +99,34 @@ with(tags, {
 
     expect_identical(
       as.character(
+        div(.noWS = "inside",
+          span(
+            strong()
+          )
+        )
+      ),
+      paste(collapse = "\n", c(
+        "<div><span>",
+        "    <strong></strong>",
+        "  </span></div>"
+      ))
+    )
+
+    expect_identical(
+      as.character(
+        div(
+          span(.noWS = c("outside", "inside"),
+            strong()
+          )
+        )
+      ),
+      paste(collapse = "\n", c(
+        "<div><span><strong></strong></span></div>"
+      ))
+    )
+
+    expect_identical(
+      as.character(
         div(
           HTML("one", .noWS = "before"),
           HTML("two")


### PR DESCRIPTION
The implementation always supported it but the validation code blocked it.