### PR TITLE
Use fixed = TRUE when finding preserve chunk locations

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -1061,11 +1061,10 @@ extractPreserveChunks <- function(strval) {
   matches <- c(startmatches, endmatches)
   o <- order(matches)
   matches <- matches[o]
-  attr(matches, "match.length") <- c(
+  lengths <- c(
     attr(startmatches, "match.length", TRUE),
     attr(endmatches, "match.length", TRUE)
   )[o]
-  lengths <- attr(matches, "match.length", TRUE)
 
   # No markers? Just return.
   if (matches[[1]] == -1)

--- a/R/tags.R
+++ b/R/tags.R
@@ -1067,7 +1067,7 @@ extractPreserveChunks <- function(strval) {
   )[o]
 
   # No markers? Just return.
-  if (matches[[1]] == -1)
+  if (identical(unique(matches), -1))
     return(list(value = strval, chunks = character(0)))
 
   # If TRUE, it's a start; if FALSE, it's an end

--- a/R/tags.R
+++ b/R/tags.R
@@ -1056,7 +1056,15 @@ extractPreserveChunks <- function(strval) {
     strval <- paste(strval, collapse = "\n")
 
   # matches contains the index of all the start and end markers
-  matches <- gregexpr(pattern, strval, perl = TRUE)[[1]]
+  startmatches <- gregexpr(startmarker, strval, fixed = TRUE)[[1]]
+  endmatches <- gregexpr(endmarker, strval, fixed = TRUE)[[1]]
+  matches <- c(startmatches, endmatches)
+  o <- order(matches)
+  matches <- matches[o]
+  attr(matches, "match.length") <- c(
+    attr(startmatches, "match.length", TRUE),
+    attr(endmatches, "match.length", TRUE)
+  )[o]
   lengths <- attr(matches, "match.length", TRUE)
 
   # No markers? Just return.


### PR DESCRIPTION
Turns out the original fix for #156 (in #157) doesn't work in R 4.0.0 (and 4.0.1) due to a bug in R itself (which is now fixed, see https://github.com/rstudio/htmltools/pull/171#issuecomment-641469977)

https://github.com/rstudio/htmltools/runs/750362532#step:12:284

Tp workaround the problem, in this case, we can use `fixed = TRUE` instead of `perl = TRUE`