### PR TITLE
Document and tests renderDocument UTF-8 encoding

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Enhances: knitr
 License: GPL (>= 2)
 URL: https://github.com/rstudio/htmltools
 BugReports: https://github.com/rstudio/htmltools/issues
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 Collate:
     'colors.R'

--- a/R/template.R
+++ b/R/template.R
@@ -94,6 +94,8 @@ htmlTemplate <- function(filename = NULL, ..., text_ = NULL, document_ = "auto")
 #'   used; it modifies the href and tells Shiny to serve a particular path on
 #'   the filesystem.
 #'
+#' @return An \code{\link{HTML}} string, with UTF-8 encoding.
+#'
 #' @export
 renderDocument <- function(x, deps = NULL, processDep = identity) {
   if (!inherits(x, "html_document")) {

--- a/man/renderDocument.Rd
+++ b/man/renderDocument.Rd
@@ -20,6 +20,9 @@ called from Shiny, the function \code{\link[shiny]{createWebDependency}} is
 used; it modifies the href and tells Shiny to serve a particular path on
 the filesystem.}
 }
+\value{
+An \code{\link{HTML}} string, with UTF-8 encoding.
+}
 \description{
 This function renders \code{html_document} objects, and returns a string with
 the final HTML content. It calls the \code{\link{renderTags}} function to

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -31,6 +31,7 @@ test_that("Code blocks are evaluated and rendered correctly", {
 test_template <- function(){
   template <- htmlTemplate("template-document.html", x = "")
   html <- renderDocument(template)
+  expect_identical(Encoding(html), "UTF-8")
 
   # Create the string 'Δ★😎', making sure it's UTF-8 encoded on all platforms.
   # These characters are 2, 3, and 4 bytes long, respectively.


### PR DESCRIPTION
This PR improves documentation for the encoding of `renderDocument`'s return value, and adds a test for it.

Related to https://github.com/rstudio/shiny/pull/2970#discussion_r455956927