### PR TITLE
(SECURITY) Allow use of "integrity" and "crossorigin" attributes when specifying script dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.0.9001
+Version: 0.5.0.9002
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.0.9002
+Version: 0.5.0.9003
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.0.9004
+Version: 0.5.0.9005
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.0.9003
+Version: 0.5.0.9004
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-htmltools 0.5.0.9004
+htmltools 0.5.0.9005
 --------------------------------------------------------------------------------
 
 * Added a new `tagFunction()` for generating `tags` and/or `htmlDependency()`s conditional on the rendering context. For an example, see `?tagFunction`. (#180)

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-htmltools 0.5.0.9000
+htmltools 0.5.0.9002
 --------------------------------------------------------------------------------
 
 * Added a new `tagFunction()` for generating `tags` and/or `htmlDependency()`s conditional on the rendering context. For an example, see `?tagFunction`. (#180)
@@ -6,6 +6,9 @@ htmltools 0.5.0.9000
 * `print(as.tags(x))` no longer results in error when `x` is a generic `list()` of tag-like objects. (#181)
 
 * `save_html()` now has a `lang` parameter that can be used to set the lang attribute of `<html>`. (@ColinFay, #185)
+
+* `htmlDependency`, & `renderDependencies` now allow the `script` argument to be given as a named list containing the
+  elements: `src`, `integrity`, `crossorigin`.
 
 htmltools 0.5.0
 --------------------------------------------------------------------------------

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-htmltools 0.5.0.9002
+htmltools 0.5.0.9004
 --------------------------------------------------------------------------------
 
 * Added a new `tagFunction()` for generating `tags` and/or `htmlDependency()`s conditional on the rendering context. For an example, see `?tagFunction`. (#180)

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -457,8 +457,7 @@ renderDependencies <- function(dependencies,
         " does not have a usable source")
 
     if (length(dep$script) > 1) {
-      usableScript <- scriptFields[which(scriptFields %in% names(dep$script))]
-      if (length(usableScript) == 0)
+      if (! all(names(script) %in% scriptFields))
         stop("Dependency ", dep$name, " ", dep$version,
           " does not have usable script fields")
     }

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -529,7 +529,7 @@ renderScript <- function(script, srcpath, encodeFunc, hrefFilter) {
 
   check_names(script)
 
-  if (length(names(script)) >= 0) script <- list(script)
+  if (length(names(script)) > 0) script <- list(script)
 
   script <- lapply(script, function(item) {
     if (length(item) == 1 && is.character(item)) {

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -36,10 +36,21 @@
 #'   \code{href} for URL. For example, a dependency that was both on disk and at
 #'   a URL might use \code{src = c(file=filepath, href=url)}.
 #'
-#'   \code{script} can be given as either a scalar string, or a named list with
-#'   the following fields: \code{src}, \code{integrity}, & \code{crossorigin},
-#'   allowing the use of SRI to ensure the integrity of packages downloaded from
-#'   remote servers.
+#'   \code{script} can be given as one of the following:
+#'   * a character vector specifying various scripts to include relative to the
+#'     value of \code{src}.
+#'     Each is expanded into its own \code{<script>} tag
+#'   * A named list with any of the following fields:
+#'     * \code{src},
+#'     * \code{integrity}, &
+#'     * \code{crossorigin},
+#'     allowing the use of SRI to ensure the integrity of packages downloaded from
+#'     remote servers.
+#'     Eg: \code{script = list(src = "min.js", integrity = "hash")}
+#'   * An unamed list, containing a combination of named list with the fields
+#'     mentioned previously, and strings.
+#'     Eg:
+#'     \code{script = list(list(src = "min.js"), "util.js", list(src = "log.js"))}
 #'   \code{script = "pkg.js"} is equivalent to
 #'   \code{script = list(src = "pkg.js")}.
 #'

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -523,7 +523,10 @@ renderDependencies <- function(dependencies,
 renderScript <- function(script, srcpath, encodeFunc, hrefFilter) {
   # If the input is a named list, transform it to an unnamed list
   # whose only element is the input list
-  if (anyNamed(script)) script <- list(script)
+  if (anyNamed(script)) {
+    if (anyUnnamed(script)) stop("script inputs cannot mix named and unnamed")
+    script <- list(script)
+  }
 
   # For each element, if it's a scalar string, transform it to a named
   # list with one element, "src".

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -429,6 +429,9 @@ makeDependencyRelative <- function(dependency, basepath, mustWork = TRUE) {
 #' @param dependencies A list of \code{htmlDependency} objects.
 #' @param srcType The type of src paths to use; valid values are \code{file} or
 #'   \code{href}.
+#' @param scriptFields The types of attributes allowed to be given as named
+#'   elements to \code{script}; valid values are \code{src}, \code{integrity}
+#'   & \code{crossorigin}.
 #' @param encodeFunc The function to use to encode the path part of a URL. The
 #'   default should generally be used.
 #' @param hrefFilter A function used to transform the final, encoded URLs of

--- a/R/utils.R
+++ b/R/utils.R
@@ -120,3 +120,31 @@ WSTextWriter <- function(bufferSize=1024) {
     }
   )
 }
+
+# Given a vector/list, return TRUE if any elements are named, FALSE otherwise.
+anyNamed <- function(x) {
+  # Zero-length vector
+  if (length(x) == 0) return(FALSE)
+
+  nms <- names(x)
+
+  # List with no name attribute
+  if (is.null(nms)) return(FALSE)
+
+  # List with name attribute; check for any ""
+  any(nzchar(nms))
+}
+
+# Given a vector/list, return TRUE if any elements are unnamed, FALSE otherwise.
+anyUnnamed <- function(x) {
+  # Zero-length vector
+  if (length(x) == 0) return(FALSE)
+
+  nms <- names(x)
+
+  # List with no name attribute
+  if (is.null(nms)) return(TRUE)
+
+  # List with name attribute; check for any ""
+  any(!nzchar(nms))
+}

--- a/man/htmlDependency.Rd
+++ b/man/htmlDependency.Rd
@@ -66,6 +66,13 @@ Each dependency can be located on the filesystem, at a relative or
   \code{href} for URL. For example, a dependency that was both on disk and at
   a URL might use \code{src = c(file=filepath, href=url)}.
 
+  \code{script} can be given as either a scalar string, or a named list with
+  the following fields: \code{src}, \code{integrity}, & \code{crossorigin},
+  allowing the use of SRI to ensure the integrity of packages downloaded from
+  remote servers.
+  \code{script = "pkg.js"} is equivalent to
+  \code{script = list(src = "pkg.js")}.
+
   \code{attachment} can be used to make the indicated files available to the
   JavaScript on the page via URL. For each element of \code{attachment}, an
   element \code{<link id="DEPNAME-ATTACHINDEX-attachment" rel="attachment"

--- a/man/htmlDependency.Rd
+++ b/man/htmlDependency.Rd
@@ -66,10 +66,21 @@ Each dependency can be located on the filesystem, at a relative or
   \code{href} for URL. For example, a dependency that was both on disk and at
   a URL might use \code{src = c(file=filepath, href=url)}.
 
-  \code{script} can be given as either a scalar string, or a named list with
-  the following fields: \code{src}, \code{integrity}, & \code{crossorigin},
-  allowing the use of SRI to ensure the integrity of packages downloaded from
-  remote servers.
+  \code{script} can be given as one of the following:
+  * a character vector specifying various scripts to include relative to the
+    value of \code{src}.
+    Each is expanded into its own \code{<script>} tag
+  * A named list with any of the following fields:
+    * \code{src},
+    * \code{integrity}, &
+    * \code{crossorigin},
+    allowing the use of SRI to ensure the integrity of packages downloaded from
+    remote servers.
+    Eg: \code{script = list(src = "min.js", integrity = "hash")}
+  * An unamed list, containing a combination of named list with the fields
+    mentioned previously, and strings.
+    Eg:
+    \code{script = list(list(src = "min.js"), "util.js", list(src = "log.js"))}
   \code{script = "pkg.js"} is equivalent to
   \code{script = list(src = "pkg.js")}.
 

--- a/man/renderDependencies.Rd
+++ b/man/renderDependencies.Rd
@@ -7,7 +7,6 @@
 renderDependencies(
   dependencies,
   srcType = c("href", "file"),
-  scriptFields = c("src", "integrity", "crossorigin"),
   encodeFunc = urlEncodePath,
   hrefFilter = identity
 )
@@ -17,10 +16,6 @@ renderDependencies(
 
 \item{srcType}{The type of src paths to use; valid values are \code{file} or
 \code{href}.}
-
-\item{scriptFields}{The types of attributes allowed to be given as named
-elements to \code{script}; valid values are \code{src}, \code{integrity}
-& \code{crossorigin}.}
 
 \item{encodeFunc}{The function to use to encode the path part of a URL. The
 default should generally be used.}

--- a/man/renderDependencies.Rd
+++ b/man/renderDependencies.Rd
@@ -7,6 +7,7 @@
 renderDependencies(
   dependencies,
   srcType = c("href", "file"),
+  scriptFields = c("src", "integrity", "crossorigin"),
   encodeFunc = urlEncodePath,
   hrefFilter = identity
 )
@@ -16,6 +17,10 @@ renderDependencies(
 
 \item{srcType}{The type of src paths to use; valid values are \code{file} or
 \code{href}.}
+
+\item{scriptFields}{The types of attributes allowed to be given as named
+elements to \code{script}; valid values are \code{src}, \code{integrity}
+& \code{crossorigin}.}
 
 \item{encodeFunc}{The function to use to encode the path part of a URL. The
 default should generally be used.}

--- a/tests/testthat/test-deps.r
+++ b/tests/testthat/test-deps.r
@@ -186,3 +186,44 @@ test_that("Modifying children using dependencies", {
   x <- tagSetChildren(div("foo", a1.1), tagFunction(function() { a1.2 }))
   expect_identical(findDependencies(x), list(a1.2))
 })
+
+
+test_that("able to resolve HTML scripts supplied with & without integrity", {
+  src1 <- "https://cdn.com/libs/p1/0.1/"
+  src2 <- "https://cdn/libs/p2/0.2/"
+  deps <- list(
+    htmlDependency(
+      name = "p1",
+      version = "0.1",
+      src = list(href = src1),
+      script = list(
+        src = "p1.min.js",
+        integrity = "longhash",
+        crossorigin = "anonymous"
+      )
+    ),
+    htmlDependency(
+      "p2", version = "0.2",
+      src = list(href = src2),
+      script = "p2.min.js"
+    )
+  )
+
+  expect1 <- paste(
+    '<script src="', src1, 'p1.min.js','" ',
+    'integrity="longhash" ',
+    'crossorigin="anonymous"></script>',
+    sep = ''
+  )
+  expect2 <- paste(
+    '<script src="', src2, 'p2.min.js','"></script>',
+    sep = ''
+  )
+
+  expect <- paste(expect1, expect2, sep = '\n')
+
+  class(expect) <- c("html", "character")
+
+
+  expect_equivalent(renderDependencies(deps), !!expect)
+})


### PR DESCRIPTION
Resolves #101 - Use of such attributes are considered best-practise for security when referencing scripts stored at remote servers: 

https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity