### PR TITLE
`validateCssUnit` allows "fit-content" (#189)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ htmltools 0.5.0.9002
 
 * Closed #101: `htmlDependency` & `renderDependencies` now allow the `script` argument to be given as a named list containing the elements: `src`, `integrity`, `crossorigin`. (@matthewstrasiotto, #188)
 
+* `validateCssUnit()` now accepts `fit-content`. (#189)
+
 htmltools 0.5.0
 --------------------------------------------------------------------------------
 

--- a/NEWS
+++ b/NEWS
@@ -9,7 +9,7 @@ htmltools 0.5.0.9002
 
 * Closed #101: `htmlDependency` & `renderDependencies` now allow the `script` argument to be given as a named list containing the elements: `src`, `integrity`, `crossorigin`. (@matthewstrasiotto, #188)
 
-* `validateCssUnit()` now accepts `fit-content`. (#189)
+* Closed #189: `validateCssUnit()` now accepts `fit-content`. (#190)
 
 htmltools 0.5.0
 --------------------------------------------------------------------------------

--- a/R/tags.R
+++ b/R/tags.R
@@ -1430,9 +1430,9 @@ is.singleton <- function(x) {
 #' Single element numeric vectors are returned as a character vector with the
 #' number plus a suffix of \code{"px"}.
 #'
-#' Single element character vectors must be \code{"auto"} or \code{"inherit"},
-#' a number, or a length calculated by the \code{"calc"} CSS function.
-#' If the number has a suffix, it must be valid: \code{px},
+#' Single element character vectors must be \code{"auto"}, \code{"fit-content"}
+#' or \code{"inherit"}, a number, or a length calculated by the \code{"calc"}
+#' CSS function. If the number has a suffix, it must be valid: \code{px},
 #' \code{\%}, \code{ch}, \code{em}, \code{rem}, \code{pt}, \code{in}, \code{cm},
 #' \code{mm}, \code{ex}, \code{pc}, \code{vh}, \code{vw}, \code{vmin}, or
 #' \code{vmax}.
@@ -1462,7 +1462,7 @@ validateCssUnit <- function(x) {
     x <- as.numeric(x)
 
   pattern <-
-    "^(auto|inherit|calc\\(.*\\)|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|ch|em|ex|rem|pt|pc|px|vh|vw|vmin|vmax))$"
+    "^(auto|inherit|fit-content|calc\\(.*\\)|((\\.\\d+)|(\\d+(\\.\\d+)?))(%|in|cm|mm|ch|em|ex|rem|pt|pc|px|vh|vw|vmin|vmax))$"
 
   if (is.character(x) &&
       !grepl(pattern, x)) {

--- a/man/htmlDependency.Rd
+++ b/man/htmlDependency.Rd
@@ -66,6 +66,31 @@ Each dependency can be located on the filesystem, at a relative or
   \code{href} for URL. For example, a dependency that was both on disk and at
   a URL might use \code{src = c(file=filepath, href=url)}.
 
+  \code{script} can be given as one of the following:
+  \itemize{
+  \item a character vector specifying various scripts to include relative to the
+    value of \code{src}.
+    Each is expanded into its own \code{<script>} tag
+  \item A named list with any of the following fields:
+  \itemize{
+    \item \code{src},
+    \item \code{integrity}, &
+    \item \code{crossorigin},
+    \item any other valid \code{<script>} attributes.
+    }
+    allowing the use of SRI to ensure the integrity of packages downloaded from
+    remote servers.
+    Eg: \code{script = list(src = "min.js", integrity = "hash")}
+  \item An unamed list, containing a combination of named list with the fields
+    mentioned previously, and strings.
+    Eg:
+    \itemize{
+    \item \code{script = list(list(src = "min.js"), "util.js", list(src = "log.js"))}
+    \item \code{script = "pkg.js"} is equivalent to
+    \item \code{script = list(src = "pkg.js")}.
+    }
+  }
+
   \code{attachment} can be used to make the indicated files available to the
   JavaScript on the page via URL. For each element of \code{attachment}, an
   element \code{<link id="DEPNAME-ATTACHINDEX-attachment" rel="attachment"

--- a/man/validateCssUnit.Rd
+++ b/man/validateCssUnit.Rd
@@ -23,9 +23,9 @@ Checks that the argument is valid for use as a CSS unit of length.
 Single element numeric vectors are returned as a character vector with the
 number plus a suffix of \code{"px"}.
 
-Single element character vectors must be \code{"auto"} or \code{"inherit"},
-a number, or a length calculated by the \code{"calc"} CSS function.
-If the number has a suffix, it must be valid: \code{px},
+Single element character vectors must be \code{"auto"}, \code{"fit-content"}
+or \code{"inherit"}, a number, or a length calculated by the \code{"calc"}
+CSS function. If the number has a suffix, it must be valid: \code{px},
 \code{\%}, \code{ch}, \code{em}, \code{rem}, \code{pt}, \code{in}, \code{cm},
 \code{mm}, \code{ex}, \code{pc}, \code{vh}, \code{vw}, \code{vmin}, or
 \code{vmax}.


### PR DESCRIPTION
`validateCssUnit()` now accepts `fit-content`. (#189)

I don't know why the file **htmlDependency.Rd** has been updated when I built the documentation.