### PR TITLE
Add raw option to htmlPreserve() to optionally enclose HTML with Pandoc raw_attribute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.0.9002
+Version: 0.5.0.9003
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ htmltools 0.5.0.9002
 
 * `save_html()` now has a `lang` parameter that can be used to set the lang attribute of `<html>`. (@ColinFay, #185)
 
+* `htmlPreserve()` can now optionally use the Pandoc `raw_attribute` extension to enclose HTML.
+
 * Closed #101: `htmlDependency` & `renderDependencies` now allow the `script` argument to be given as a named list containing the elements: `src`, `integrity`, `crossorigin`. (@matthewstrasiotto, #188)
 
 * Closed #189: `validateCssUnit()` now accepts `fit-content`. (#190)

--- a/R/tags.R
+++ b/R/tags.R
@@ -1040,6 +1040,9 @@ as.tags.html_dependency <- function(x, ...) {
 #'
 #' @param x A character vector of HTML to be preserved.
 #'
+#' @param raw Preserve HTML using Pandoc `raw_attribute`
+#'  (https://pandoc.org/MANUAL.html#extension-raw_attribute)
+#'
 #' @return \code{htmlPreserve} returns a single-element character vector with
 #'   "magic" HTML comments surrounding the original text (unless the original
 #'   text was empty, in which case an empty string is returned).
@@ -1060,10 +1063,20 @@ as.tags.html_dependency <- function(x, ...) {
 #' output
 #'
 #' @export
-htmlPreserve <- function(x) {
+htmlPreserve <- function(x, raw = getOption("htmltools.preserve.raw", FALSE)) {
   x <- paste(x, collapse = "\n")
   if (nzchar(x))
-    sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x)
+    if (raw) {
+      # use fenced code block if there are embedded newlines
+      if (grepl("\n", x, fixed = TRUE))
+        sprintf("\n```{=html}\n%s\n```\n", x)
+      # otherwise use inline span
+      else
+        sprintf("`%s`{=html}", x)
+    }
+    else {
+      sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x)
+    }
   else
     x
 }

--- a/man/htmlPreserve.Rd
+++ b/man/htmlPreserve.Rd
@@ -6,7 +6,7 @@
 \alias{restorePreserveChunks}
 \title{Preserve HTML regions}
 \usage{
-htmlPreserve(x)
+htmlPreserve(x, raw = getOption("htmltools.preserve.raw", FALSE))
 
 extractPreserveChunks(strval)
 
@@ -14,6 +14,9 @@ restorePreserveChunks(strval, chunks)
 }
 \arguments{
 \item{x}{A character vector of HTML to be preserved.}
+
+\item{raw}{Preserve HTML using Pandoc `raw_attribute`
+(https://pandoc.org/MANUAL.html#extension-raw_attribute)}
 
 \item{strval}{Input string from which to extract/restore chunks.}
 


### PR DESCRIPTION
See https://pandoc.org/MANUAL.html#extension-raw_attribute. 

This extension is available in Pandoc >= v2.0 and is enabled by default for markdown input.
