### PR TITLE
save_html() now works with a subdirectory file or connection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ htmltools 0.5.0.9002
 
 * `save_html()` now has a `lang` parameter that can be used to set the lang attribute of `<html>`. (@ColinFay, #185)
 
+* `save_html()`'s `file` argument now properly handles relative paths. (@haozhu233, #105)
+
 * Closed #101: `htmlDependency` & `renderDependencies` now allow the `script` argument to be given as a named list containing the elements: `src`, `integrity`, `crossorigin`. (@matthewstrasiotto, #188)
 
 * Closed #189: `validateCssUnit()` now accepts `fit-content`. (#190)
@@ -65,8 +67,6 @@ htmltools 0.4.0
 
 * Fixed #99: `NA` attributes were sometimes rendered as `"NA"` in the HTML,
   instead of being blank. (#100)
-  
-* Fixed #104: `save_html()` cannot recognize relative path. (#105)
 
 * The error message for trailing commas in tag functions now provides context
   and useful information. (#109)

--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,8 @@ htmltools 0.4.0
 
 * Fixed #99: `NA` attributes were sometimes rendered as `"NA"` in the HTML,
   instead of being blank. (#100)
+  
+* Fixed #104: `save_html()` cannot recognize relative path. (#105)
 
 * The error message for trailing commas in tag functions now provides context
   and useful information. (#109)

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ htmltools 0.5.0.9002
 
 * `save_html()` now has a `lang` parameter that can be used to set the lang attribute of `<html>`. (@ColinFay, #185)
 
-* `save_html()`'s `file` argument now properly handles relative paths. (@haozhu233, #105)
+* Closed #104: `save_html()`'s `file` argument now properly handles relative paths. (@haozhu233, #105)
 
 * Closed #101: `htmlDependency` & `renderDependencies` now allow the `script` argument to be given as a named list containing the elements: `src`, `integrity`, `crossorigin`. (@matthewstrasiotto, #188)
 

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@ htmltools 0.5.0.9002
 
 * `save_html()` now has a `lang` parameter that can be used to set the lang attribute of `<html>`. (@ColinFay, #185)
 
-* Closed #104: `save_html()`'s `file` argument now properly handles relative paths. (@haozhu233, #105)
+* Closed #104: `save_html()`'s `file` argument now properly handles relative paths. (@haozhu233, #105, #192)
 
 * Closed #101: `htmlDependency` & `renderDependencies` now allow the `script` argument to be given as a named list containing the elements: `src`, `integrity`, `crossorigin`. (@matthewstrasiotto, #188)
 

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -79,6 +79,8 @@ save_html <- function(html, file, background = "white", libdir = "lib", lang = "
   if (is.character(file)) {
     dir <- normalizePath(dirname(file), mustWork = TRUE)
     file <- file.path(dir, basename(file))
+    owd <- setwd(dir)
+    on.exit(setwd(owd), add = TRUE)
   }
 
   rendered <- renderTags(html)

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -76,11 +76,10 @@ save_html <- function(html, file, background = "white", libdir = "lib", lang = "
 
   # ensure that the paths to dependencies are relative to the base
   # directory where the webpage is being built.
-  base_file <- basename(file)
-  dir <- normalizePath(dirname(file))
-  file <- file.path(dir, base_file)
-  oldwd <- setwd(dir)
-  on.exit(setwd(oldwd), add = TRUE)
+  if (is.character(file)) {
+    dir <- normalizePath(dirname(file), mustWork = TRUE)
+    file <- file.path(dir, basename(file))
+  }
 
   rendered <- renderTags(html)
 

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -64,7 +64,8 @@ html_print <- function(html, background = "white", viewer = getOption("viewer", 
 #'
 #' @param html HTML content to print
 #' @param background Background color for web page
-#' @param file File to write content to
+#' @param file File path or connection. If a file path containing a
+#'   sub-directory, the sub-directory must already exist.
 #' @param libdir Directory to copy dependencies to
 #' @param lang Value of the `<html>` `lang` attribute
 #'

--- a/R/html_print.R
+++ b/R/html_print.R
@@ -76,7 +76,9 @@ save_html <- function(html, file, background = "white", libdir = "lib", lang = "
 
   # ensure that the paths to dependencies are relative to the base
   # directory where the webpage is being built.
-  dir <- dirname(file)
+  base_file <- basename(file)
+  dir <- normalizePath(dirname(file))
+  file <- file.path(dir, base_file)
   oldwd <- setwd(dir)
   on.exit(setwd(oldwd), add = TRUE)
 

--- a/man/save_html.Rd
+++ b/man/save_html.Rd
@@ -9,7 +9,8 @@ save_html(html, file, background = "white", libdir = "lib", lang = "en")
 \arguments{
 \item{html}{HTML content to print}
 
-\item{file}{File to write content to}
+\item{file}{File path or connection. If a file path containing a
+sub-directory, the sub-directory must already exist.}
 
 \item{background}{Background color for web page}
 

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -79,3 +79,23 @@ test_that("save_html() language parameter is set", {
     grepl("<html lang=\"fr\">", paste(output_read, collapse = " "))
   )
 })
+
+test_that("save_html() can write to subdirectories", {
+  tmpDir <- tempfile()
+  dir.create(tmpDir)
+  withr::local_dir(tmpDir)
+  dir.create("foo")
+  save_html(tags$h2("Howdy"), "foo/bar.html")
+  expect_true(
+    grepl("<h2>Howdy</h2>", paste(readLines("foo/bar.html"), collapse = " "))
+  )
+})
+
+test_that("save_html() can write to a file connection", {
+  f <- file()
+  on.exit(close(f), add = TRUE)
+  save_html(tags$h2("Howdy"), f)
+  expect_true(
+    grepl("<h2>Howdy</h2>", paste(readLines(f), collapse = " "))
+  )
+})


### PR DESCRIPTION
Supercedes #104. This also makes `save_html()` work with  `file()` connections, which was for some reason partially addressed in https://github.com/rstudio/htmltools/commit/3dba0188715f09883f9efb1bf46956a6e1f823f8, but I don't think that has ever worked (until now)