### PR TITLE
Start 0.5.1.1 release candidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.1.9000
+Version: 0.5.1.1
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),
@@ -24,7 +24,8 @@ Suggests:
     testthat,
     withr,
     Cairo,
-    ragg
+    ragg,
+    shiny
 Enhances: knitr
 License: GPL (>= 2)
 URL: https://github.com/rstudio/htmltools

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 htmltools 0.5.1.1
 --------------------------------------------------------------------------------
 
-Added shiny as a suggested package.
+* Added shiny as a suggested package.
 
 
 htmltools 0.5.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
-htmltools 0.5.1.9000
+htmltools 0.5.1.1
 --------------------------------------------------------------------------------
+
+Added shiny as a suggested package.
 
 
 htmltools 0.5.1


### PR DESCRIPTION
Addresses:

```
Dear maintainer,

Please see the problems shown on
<https://cran.r-project.org/web/checks/check_results_htmltools.html>.

Please correct before 2021-02-04 to safely retain your package on CRAN.

Note that this will be the *final* reminder.

The CRAN Team
```

Which appears to be referencing this Rd link to shiny https://github.com/rstudio/htmltools/blame/master/R/template.R#L93

This should fix the problem by suggesting shiny

- [x] Create branch labelled rc-v0.5.1.1
- [x] Change the DESCRIPTION and NEWS on this branch to change the version number to the desired version for CRAN
- [x] Commit and push to the RC branch.
- [x] Make sure all upstream dependencies are accepted on CRAN.
- [x] Remove Remotes from DESCRIPTION.
- [x] Build package
- [x] Do a sanity check by installing/testing the built package.
- [x] Run R CMD check --as-cran pkg_version.tar.gz both locally and on win-builder. You can also use https://r-hub.github.io/rhub/.
- [ ] Perform revdepcheck.
- [x] Submit to CRAN
- [x] If there are R CMD check warnings that are unavoidable, make sure to explain them in the comments.
- [x] Tag release
- [x] Merge tag into master
- [x] Delete RC branch
- [x] Rebuild and deploy website
- [ ] Create GitHub release, and copy NEWS items into release notes
- [ ] Bump version number