### PR TITLE
doRenderTags() now handles a top-level tagFunction()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ htmltools 0.5.1.9000
 --------------------------------------------------------------------------------
 
 * Closed #197: Fixed rendering of boolean attributes in <script> tags rendered via renderDependencies() (#197, thanks @atusy).
+* Closed #204: doRenderTags() now works when provided a top-level tagFunction(). (#204)
 
 htmltools 0.5.1.1
 --------------------------------------------------------------------------------

--- a/R/tags.R
+++ b/R/tags.R
@@ -608,6 +608,9 @@ renderTags <- function(x, singletons = character(0), indent = 0) {
 #' @rdname renderTags
 #' @export
 doRenderTags <- function(x, indent = 0) {
+  if (is_tag_function(x)) {
+    x <- tagify(x)
+  }
   textWriter <- WSTextWriter()
   tagWrite(x, textWriter, indent)
   # Strip off trailing \n (if present?)

--- a/R/tags.R
+++ b/R/tags.R
@@ -608,6 +608,8 @@ renderTags <- function(x, singletons = character(0), indent = 0) {
 #' @rdname renderTags
 #' @export
 doRenderTags <- function(x, indent = 0) {
+  # tagWrite() expects that x is already a tag or tagList()
+  # so first tagify a top-level tagFunction()
   if (is_tag_function(x)) {
     x <- tagify(x)
   }

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -765,6 +765,25 @@ test_that("Non-tag objects can be coerced", {
 
 })
 
+test_that("doRenderTags() works", {
+  expect_equal(
+    doRenderTags(div("foo")),
+    HTML("<div>foo</div>")
+  )
+  expect_equal(
+    doRenderTags(tagList(div("foo"), div("bar"))),
+    HTML("<div>foo</div>\n<div>bar</div>")
+  )
+  expect_equal(
+    doRenderTags(tagFunction(function() { div("foo") })),
+    HTML("<div>foo</div>")
+  )
+  expect_equal(
+    doRenderTags(tagFunction(function() { tagFunction(function() {  div("foo") }) })),
+    HTML("<div>foo</div>")
+  )
+})
+
 test_that("Latin1 and system encoding are converted to UTF-8", {
   #Sys.setlocale(, "Chinese")
   latin1_str <- rawToChar(as.raw(0xFF))


### PR DESCRIPTION
Closes #203