### PR TITLE
Provide an error when parsing unimplemented css selections

### DIFF
--- a/R/selector.R
+++ b/R/selector.R
@@ -30,21 +30,22 @@ asSelector <- function(selector) {
   selector <- txt_trim(paste0(selector, collapse = " "))
 
   if (txt_detect(selector, ",", fixed = TRUE)) {
-    stop("Currently, `asSelector()` can not handle comma separated CSS selector values")
+    stop("CSS selectors that contain `,` aren't (yet) implemented.", call. = FALSE)
   }
   if (txt_detect(selector, "[", fixed = TRUE)) {
-    stop("Currently, `asSelector()` can not handle `[` in CSS selector values")
+    stop("CSS selectors that contain `[` aren't (yet) implemented.", call. = FALSE)
   }
   if (txt_detect(selector, "~", fixed = TRUE)) {
-    stop("Currently, `asSelector()` can not handle `~` in CSS selector values")
+    stop("CSS selectors that contain `~` aren't (yet) implemented.", call. = FALSE)
   }
   if (txt_detect(selector, "+", fixed = TRUE)) {
-    stop("Currently, `asSelector()` can not handle `+` in CSS selector values")
+    stop("CSS selectors that contain `+` aren't (yet) implemented.", call. = FALSE)
   }
   if (txt_detect(selector, ":", fixed = TRUE)) {
     stop(
-      "Currently, `asSelector()` can not handle special pseudo classes like",
-      " `:first-child` or `:not()` in CSS selector values"
+      "Pseudo CSS selectors (e.g., `:first-child`, `:not()`, etc)",
+      "aren't (yet) implemented.",
+      call. = FALSE
     )
   }
 

--- a/R/selector.R
+++ b/R/selector.R
@@ -44,7 +44,7 @@ asSelector <- function(selector) {
   if (txt_detect(selector, ":", fixed = TRUE)) {
     stop(
       "Pseudo CSS selectors (e.g., `:first-child`, `:not()`, etc)",
-      "aren't (yet) implemented.",
+      " aren't (yet) implemented.",
       call. = FALSE
     )
   }

--- a/R/selector.R
+++ b/R/selector.R
@@ -29,24 +29,18 @@ asSelector <- function(selector) {
   # make sure it's a trimmed string
   selector <- txt_trim(paste0(selector, collapse = " "))
 
-  # yell if there is a comma
   if (txt_detect(selector, ",", fixed = TRUE)) {
     stop("Currently, `asSelector()` can not handle comma separated CSS selector values")
   }
-  # yell if there is a `[`
   if (txt_detect(selector, "[", fixed = TRUE)) {
     stop("Currently, `asSelector()` can not handle `[` in CSS selector values")
   }
-  # yell if there is a `[`
   if (txt_detect(selector, "~", fixed = TRUE)) {
     stop("Currently, `asSelector()` can not handle `~` in CSS selector values")
   }
-  # yell if there is a `[`
   if (txt_detect(selector, "+", fixed = TRUE)) {
     stop("Currently, `asSelector()` can not handle `+` in CSS selector values")
   }
-
-  # yell if there is a `:`
   if (txt_detect(selector, ":", fixed = TRUE)) {
     stop(
       "Currently, `asSelector()` can not handle special pseudo classes like",

--- a/R/selector.R
+++ b/R/selector.R
@@ -31,16 +31,27 @@ asSelector <- function(selector) {
 
   # yell if there is a comma
   if (txt_detect(selector, ",", fixed = TRUE)) {
-    stop("Do not know how to handle comma separated selector values")
+    stop("Currently, `asSelector()` can not handle comma separated CSS selector values")
   }
   # yell if there is a `[`
   if (txt_detect(selector, "[", fixed = TRUE)) {
-    stop("Do not know how to handle `[` in selector values")
+    stop("Currently, `asSelector()` can not handle `[` in CSS selector values")
+  }
+  # yell if there is a `[`
+  if (txt_detect(selector, "~", fixed = TRUE)) {
+    stop("Currently, `asSelector()` can not handle `~` in CSS selector values")
+  }
+  # yell if there is a `[`
+  if (txt_detect(selector, "+", fixed = TRUE)) {
+    stop("Currently, `asSelector()` can not handle `+` in CSS selector values")
   }
 
   # yell if there is a `:`
   if (txt_detect(selector, ":", fixed = TRUE)) {
-    stop("Do not know how to handle special pseudo classes like `:first-child` or `:not()` in selector values")
+    stop(
+      "Currently, `asSelector()` can not handle special pseudo classes like",
+      " `:first-child` or `:not()` in CSS selector values"
+    )
   }
 
   # if it contains multiple elements, recurse

--- a/tests/testthat/test-selector.R
+++ b/tests/testthat/test-selector.R
@@ -19,9 +19,9 @@ makeTags <- function(text1, text2) {
 }
 
 test_that("error checks", {
-  expect_error(asSelector("div, span"), "comma")
-  expect_error(asSelector("div[foo]"), "`[`", fixed = TRUE)
-  expect_error(asSelector("div:text"), "pseudo classes")
+  expect_error(asSelector("div, span"), "contain `,`")
+  expect_error(asSelector("div[foo]"), "contain `[`", fixed = TRUE)
+  expect_error(asSelector("div:text"), "Pseudo CSS selectors")
 })
 
 


### PR DESCRIPTION
Throw on `~`, `+`, `,`, `:`, `[`