### PR TITLE
Have `$selected()` and `$root()` return tags. Remove `$asTags()` and `$get()`

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -376,15 +376,15 @@ print.htmltools.tag.query <- function(x, ...) {
 #' @export
 format.htmltools.tag.query <- function(x, ...) {
   stop(
-    "`format.htmltools.tag.query(x)` not allowed.\n",
-    "Please call `format()` the result of `$selected()`"
+    "`tagQuery()` objects can not be written directly as HTML tags.\n",
+    "Call either `$root()` or `$selected()` to extract the tags of interest."
   )
 }
 #' @export
 as.character.htmltools.tag.query <- function(x, ...) {
   stop(
-    "`as.character.htmltools.tag.query(x)` not allowed.\n",
-    "Please call `as.character()` the result of `$selected()`"
+    "`tagQuery()` objects can not be written directly as HTML tags.\n",
+    "Call either `$root()` or `$selected()` to extract the tags of interest."
   )
 }
 

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -9,7 +9,7 @@ tagQuery(tags)
 \arguments{
 \item{tags}{Any standard tag object or \code{tagList()}. If a \code{list()} or
 \code{tagList()} is provided, a \code{tagList()} will be returned when calling
-\verb{$asTags()}.}
+\verb{$selected()}.}
 }
 \value{
 A \code{tagQuery()} object. The \code{tag} supplied will be considered the
@@ -37,7 +37,7 @@ For example, it is difficult to find a set of tags and alter the parent tag
 when working with standard \code{\link{tag}} objects. With \code{tagQuery()}, it is possible
 to find all \verb{<span>} tags that match the css selector \verb{div .inner span}, then
 ask for the grandparent tag objects, then add a class to these grandparent
-tag elements.  This could be accomplished using code similar to\if{html}{\out{<div class="r tagQuery(ex_tags)$find("div .inner">}}\preformatted{span")$parent()$parent()$addClass("custom-class")$asTags(selected = FALSE)
+tag elements.  This could be accomplished using code similar to\if{html}{\out{<div class="r tagQuery(ex_tags)$find("div .inner">}}\preformatted{span")$parent()$parent()$addClass("custom-class")$root()
 }\if{html}{\out{</div>}}
 
 This style of alteration is not easily achieved when using typical "pass by
@@ -53,7 +53,7 @@ reference). Meaning that if a css class is added to each selected tag
 environment using \verb{$addClass()} and the result of the method call is ignored,
 the selected tag environments within the tag query object will still contain
 the class addition.  The added class will exist when the tag query tag
-environment are converted back to standard tags objects with \verb{$asTags()}.
+environment are converted back to standard tags objects with \verb{$selected()}.
 
 Tag environments also contain an extra field, \code{.$parent}. The \code{.$parent}
 value contains their parent tag environment. The top level tags supplied to
@@ -71,7 +71,7 @@ parent to child relationship and up to 1 parent per child.
 A \code{tagQuery()} behaves simliar to an R6 object in that internal values are
 altered in place. (but a \code{tagQuery()} object is not implemented with \code{R6}).
 The \code{tagQuery()}'s methods will return itself as much as possible, unless the
-method is directly asking for information, e.g. \verb{$selected()} or \verb{$asTags()}.
+method is directly asking for information, e.g. \verb{$root()} or \verb{$selected()}.
 
 Internally, two important pieces of information are maintained: the root
 elements and the selected elements. The root tag environment will always
@@ -83,23 +83,23 @@ environment. All \code{tagQuery()} methods will act on the selected elements
 unless declared otherwise.
 
 Tag query objects can be created from other tag query objects. Note, unless
-there is an intermediate call to \verb{$asTags()}, the original and new tag query
+there is an intermediate call to \verb{$selected()}, the original and new tag query
 objects will share the same tag environments. The new tag query object will
 have its selected elements reset. For example:\if{html}{\out{<div class="r">}}\preformatted{x <- tagQuery(div())
 y <- tagQuery(x)
-z <- tagQuery(x$asTags(selected = FALSE))
+z <- tagQuery(x$root())
 
 # Add an example class
 y$addClass("example")
 
 # Show `x` and `y` both have the new class
-x$asTags()
+x$selected()
 #> <div class="example"></div>
-y$asTags()
+y$selected()
 #> <div class="example"></div>
 
-# `z` is isolated from the changes in `x` and `y` due to the `$asTags()`
-z$asTags()
+# `z` is isolated from the changes in `x` and `y` due to the `$selected()`
+z$selected()
 #> <div></div>
 }\if{html}{\out{</div>}}
 }
@@ -109,7 +109,7 @@ z$asTags()
 
 
 \code{tagQuery()}s can \strong{not} be used directly within typical \code{tag} locations.
-An error should be thrown. Instead, please call \verb{$asTags()} to retrieve the
+An error should be thrown. Instead, please call \verb{$selected()} to retrieve the
 tag structures of the selected tag elements or root element respectively.
 }
 
@@ -247,19 +247,14 @@ tag query object.
 
 \subsection{Tag Query methods}{
 \itemize{
-\item \verb{$asTags(selected = TRUE)}: If \code{selected = TRUE}, then all
-previously found elements (and their descendants) will be
-converted to tags. If \code{selected = FALSE}, the top level tag
-elements (and their descendants) will be converted to
-standard tags. If there is more than one element being
-returned, a \code{tagList()} will be used to hold all of the
-objects.
-\item \verb{$root()}: Return all top level (root) tags environments. If there
-are more than one, it will be returned within a \code{tagList()}. If there
-is only one tag, it will be returned.
-\item \verb{$selected()}: Returns a list of selected tag environments.
-\item \verb{$get(position)}: Returns the selected tag element at the position
-\code{position}.
+\item \verb{$root()}: Converts the top level tag
+elements (and their descendants) from tag environments to
+standard \code{\link{tag}} objects. If there is more than one element being
+returned, a \code{\link[=tagList]{tagList()}} will be used to hold all of the
+tags.
+\item \verb{$selected()}: Converts the selected tag environments
+to standard \code{\link{tag}} objects. The selected tags will be returned in a
+\code{\link[=tagList]{tagList()}}.
 \item \verb{$rebuild()}: Makes sure that all tags have been upgraded to tag
 environments. Objects wrapped in \code{HTML()} will not be inspected or
 altered. This method is internally called before each method executes


### PR DESCRIPTION
Fixes https://github.com/rstudio/htmltools/issues/221
Fixes https://github.com/rstudio/htmltools/issues/213