### PR TITLE
tagQuery(): Rebuild less often and do not check for tag env cycles; Rename `$reset()` -> `$resetSelected()`

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -558,10 +558,7 @@ tagQuery_ <- function(
     asTagEnv(root)
   }
 
-  newTagQuery <- function(selected, rebuild = FALSE) {
-    if (rebuild) {
-      rebuild_()
-    }
+  newTagQuery <- function(selected) {
     tagQuery_(root, selected)
   }
 
@@ -619,8 +616,6 @@ tagQuery_ <- function(
         #' with the matching set of tag environments. A new `tagQuery()` object
         #' will be created with the selected items set to the found elements.
         find = function(cssSelector) {
-          rebuild_()
-
           newTagQuery(
             tagQueryFindAll(selected_, cssSelector)
           )
@@ -632,7 +627,6 @@ tagQuery_ <- function(
         #' object will be created with the selected items set to the children
         #' elements.
         children = function(cssSelector = NULL) {
-          rebuild_()
           newTagQuery(
             tagQueryFindChildren(selected_, cssSelector)
           )
@@ -644,7 +638,6 @@ tagQuery_ <- function(
         #' object will be created with the selected items set to the parent
         #' elements.
         parent = function(cssSelector = NULL) {
-          rebuild_()
           newTagQuery(
             tagQueryFindParent(selected_, cssSelector)
           )
@@ -656,7 +649,6 @@ tagQuery_ <- function(
         #' object will be created with the selected items set to the ancestor
         #' elements.
         parents = function(cssSelector = NULL) {
-          rebuild_()
           newTagQuery(
             tagQueryFindParents(selected_, cssSelector)
           )
@@ -667,7 +659,6 @@ tagQuery_ <- function(
         #' equivalent to calling `$selected()`. A new `tagQuery()` object will be
         #' created with the selected items set to the closest matching elements.
         closest = function(cssSelector = NULL) {
-          rebuild_()
           newTagQuery(
             tagQueryFindClosest(selected_, cssSelector)
           )
@@ -678,7 +669,6 @@ tagQuery_ <- function(
         #' new `tagQuery()` object will be created with the selected items set
         #' to the sibling elements.
         siblings = function(cssSelector = NULL) {
-          rebuild_()
           newTagQuery(
             tagQueryFindSiblings(selected_, cssSelector)
           )
@@ -688,18 +678,17 @@ tagQuery_ <- function(
         #' selector, then the selected elements will be filtered if they match
         #' the single-element CSS selector. A new `tagQuery()` object will be
         #' created with the selected items set to the filtered selected
-        #' elements.
+        #' elements. Remember, any alterations to the provided tag environments will persist
+        #' in calling tag query object. If you need to make local changes, consider
+        #' using `tagQuery(el)$selected()` to use standard tag objects.
         filter = function(fn) {
+          newSelected <- tagQueryFindFilter(selected_, fn)
           rebuild_()
-          newTagQuery(
-            tagQueryFindFilter(selected_, fn),
-            rebuild = TRUE
-          )
+          newTagQuery(newSelected)
         },
         #' * `$reset()`: A new `tagQuery()` object will be created with the
         #' selected items set to the top level tag objects.
         reset = function() {
-          rebuild_()
           newTagQuery(
             tagQueryFindReset(root)
           )
@@ -712,27 +701,23 @@ tagQuery_ <- function(
         #' * `$addClass(class)`: Apps class(es) to each of the the selected
         #' elements.
         addClass = function(class) {
-          rebuild_()
           tagQueryClassAdd(selected_, class)
           invisible(self)
         },
         #' * `$removeClass(class)`: Removes a set of class values from all of
         #' the selected elements.
         removeClass = function(class) {
-          rebuild_()
           tagQueryClassRemove(selected_, class)
           invisible(self)
         },
         #' * `$hasClass(class)`: Determine whether the selected elements have a
         #' given class. Returns a vector of logical values.
         hasClass = function(class) {
-          rebuild_()
           tagQueryClassHas(selected_, class)
         },
         #' * `$toggleClass(class)`: If the a class value is missing, add it. If
         #' a  class value already exists, remove it.
         toggleClass = function(class) {
-          rebuild_()
           tagQueryClassToggle(selected_, class)
           invisible(self)
         },
@@ -740,29 +725,24 @@ tagQuery_ <- function(
         #' * `$addAttrs(...)`: Add named attributes to all selected children.
         #' Similar to [`tagAppendAttributes()`].
         addAttrs = function(...) {
-          rebuild_()
           tagQueryAttrsAdd(selected_, ...)
-          # no need to rebuild_(); already flattened in add attr function
           invisible(self)
         },
         #' * `$removeAttrs(attrs)`: Removes the provided attributes in each of
         #' the selected elements.
         removeAttrs = function(attrs) {
-          rebuild_()
           tagQueryAttrsRemove(selected_, attrs)
           invisible(self)
         },
         #' * `$emptyAttrs()`: Removes all attributes in each of the selected
         #' elements.
         emptyAttrs = function() {
-          rebuild_()
           tagQueryAttrsEmpty(selected_)
           invisible(self)
         },
         #' * `$hasAttr(attr)`: Returns a vector whose values are whether the
         #' selected element contains the non-`NULL` attribute.
         hasAttr = function(attr) {
-          rebuild_()
           tagQueryAttrHas(selected_, attr)
         },
 
@@ -772,27 +752,21 @@ tagQuery_ <- function(
         #' existing children to the selected elements. Similar to
         #' [`tagAppendChildren()`]
         append = function(...) {
-          rebuild_()
           tagQueryChildrenAppend(selected_, ...)
-          rebuild_()
           invisible(self)
         },
         #' * `$prepend(...)`: Add all `...` objects as children **before** any
         #' existing children to the selected elements. A variation of
         #' [`tagAppendChildren()`]
         prepend = function(...) {
-          rebuild_()
           tagQueryChildrenPrepend(selected_, ...)
-          rebuild_()
           invisible(self)
         },
         #' * `$empty()`: Remove all children in the selected elements. Use this
         #' method before calling `$append(...)` to replace all selected
         #' elements' children.
         empty = function() {
-          rebuild_()
           tagQueryChildrenEmpty(selected_)
-          # no need to rebuild_
           invisible(self)
         },
         ## end Adjust Children
@@ -802,36 +776,30 @@ tagQuery_ <- function(
         #' * `$after(...)`: Add all `...` objects as siblings after each of the
         #' selected elements.
         after = function(...) {
-          rebuild_()
           tagQuerySiblingAfter(selected_, ...)
-          # rebuild_() # rebuild done within method
           invisible(self)
         },
         #' * `$before(...)`: Add all `...` objects as siblings before each of
         #' the selected elements.
         before = function(...) {
-          rebuild_()
           tagQuerySiblingBefore(selected_, ...)
-          # rebuild_() # rebuild done within method
           invisible(self)
         },
         #' * `$replaceWith(...)`: Replace all selected elements with `...`. This
         #' also sets the selected elements to an empty set. A new `tagQuery()`
         #' object will be created with an empty set of selected elements.
         replaceWith = function(...) {
-          rebuild_()
           tagQuerySiblingReplaceWith(selected_, ...)
-          newTagQuery(list(), rebuild = FALSE) # rebuild done within method
+          newTagQuery(list())
         },
         #' * `$remove(...)`: Remove all selected elements from the `tagQuery()`
         #' object. The selected elements is set to an empty set. A new
         #' `tagQuery()` object will be created with an empty set of selected
         #' elements.
         remove = function() {
-          rebuild_()
           tagQuerySiblingRemove(selected_)
           # Remove items from selected info
-          newTagQuery(list(), rebuild = FALSE) # no rebuild necessary
+          newTagQuery(list())
         },
         ## end Adjust Siblings
 
@@ -844,12 +812,13 @@ tagQuery_ <- function(
         #' argument order is different than jQuery's `$().each()` as there is no
         #' concept of a `this` object inside the function execution. To stay
         #' consistent with other methods, the each of the selected tag
-        #' environments will be given first, followed by the index position. Any
-        #' alterations to the provided tag environments will persist in calling
-        #' tag query object.
+        #' environments will be given first, followed by the index position.
+        #' Remember, any alterations to the provided tag environments will persist
+        #' in calling tag query object. If you need to make local changes, consider
+        #' using `tagQuery(el)$selected()` to use standard tag objects.
         each = function(fn) {
-          rebuild_()
           tagQueryEach(selected_, fn)
+          # MUST rebuild full tree as anything could have been done to the tag envs
           rebuild_()
           invisible(self)
         },
@@ -863,14 +832,12 @@ tagQuery_ <- function(
         #' returned, a [`tagList()`] will be used to hold all of the
         #' tags.
         root = function() {
-          rebuild_()
           tagQueryRootAsTags(root)
         },
         #' * `$selected()`: Converts the selected tag environments
         #' to standard [`tag`] objects. The selected tags will be returned in a
         #' [`tagList()`].
         selected = function() {
-          rebuild_()
           tagQuerySelectedAsTags(selected_)
         },
         #' * `$rebuild()`: Makes sure that all tags have been upgraded to tag
@@ -879,13 +846,11 @@ tagQuery_ <- function(
         #' and after any alterations where standard tag objects could be
         #' introduced into the tag structure.
         rebuild = function() {
-          rebuild_()
           invisible(self)
         },
         #' * `$print()`: Internal print method. Called by
         #' `print.htmltools.tag.query()`
         print = function() {
-          rebuild_()
           # Allows `$print()` to know if there is a root el
           tagQueryPrint(root, selected_)
           invisible(self)
@@ -1111,7 +1076,8 @@ selectedWalkGen <- function(func) {
         if (isTag(el) && !isTagEnv(el)) {
           str(el)
           stop(
-            "Object in position `", i, "` is a regular `tag()` and not a tag environment"
+            "Object in position `", i, "` is a regular `tag()` and not a tag environment.",
+            "\nDid you forget to call `$rebuild()`?"
           )
         }
       }
@@ -1148,6 +1114,9 @@ tagQueryMatchChildRev <- function(els, func) {
       childKey <- child$envKey
       if (elKey == childKey) {
         func(elParent, el, childPos)
+        # Make sure to rebuild the parent tag into tag envs
+        # Their internal structures will have changed
+        asTagEnv(elParent)
       }
     })
   })
@@ -1165,16 +1134,12 @@ tagQuerySiblingRemove <- function(els) {
 tagQuerySiblingAfter <- function(els, ...) {
   tagQueryMatchChildRev(els, function(elParent, el, childPos) {
     tagInsertChildren(elParent, after = childPos, ...)
-    # Make sure to rebuild the parent tag into tag envs
-    asTagEnv(elParent)
   })
 }
 # Add siblings before each el
 tagQuerySiblingBefore <- function(els, ...) {
   tagQueryMatchChildRev(els, function(elParent, el, childPos) {
     tagInsertChildren(elParent, after = childPos - 1, ...)
-    # Make sure to rebuild the parent tag into tag envs
-    asTagEnv(elParent)
   })
 }
 # Replace all `el` objects with `...`
@@ -1185,27 +1150,29 @@ tagQuerySiblingReplaceWith <- function(els, ...) {
     elParent$children[[childPos]] <- NULL
     # Replace with ... content where the child was
     tagInsertChildren(elParent, after = childPos - 1, ...)
-    # Make sure to rebuild the parent tag into tag envs
-    asTagEnv(elParent)
   })
 }
 
 
-tagQuerySetChildren <- function(els, ...) {
+tagQueryChildrenSet <- function(els, ...) {
   tagQueryWalk(els, function(el) {
     if (!isTagEnv(el)) return()
     tagSetChildren(el, ...)
+    # Make sure to rebuild the el and its children
+    asTagEnv(el)
   })
 }
 tagQueryChildrenEmpty <- function(els) {
   # do not include any arguments.
   # `dots_list()` returns an empty named list()
-  tagQuerySetChildren(els)
+  tagQueryChildrenSet(els)
 }
 tagQueryChildrenAppend <- function(els, ...) {
   tagQueryWalk(els, function(el) {
     if (!isTagEnv(el)) return()
     tagInsertChildren(el, after = length(el$children), ...)
+    # Make sure to rebuild the el and its children
+    asTagEnv(el)
   })
 }
 tagQueryChildrenPrepend <- function(els, ...) {
@@ -1215,6 +1182,8 @@ tagQueryChildrenInsert <- function(els, after, ...) {
   tagQueryWalk(els, function(el) {
     if (!isTagEnv(el)) return()
     tagInsertChildren(el, after = after, ...)
+    # Make sure to rebuild the el and its children
+    asTagEnv(el)
   })
 }
 

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -813,7 +813,7 @@ tagQuery_ <- function(
         after = function(...) {
           rebuild_()
           tagQuerySiblingAfter(selected_, ...)
-          rebuild_()
+          # rebuild_() # rebuild done within method
           invisible(self)
         },
         #' * `$before(...)`: Add all `...` objects as siblings before each of
@@ -821,7 +821,7 @@ tagQuery_ <- function(
         before = function(...) {
           rebuild_()
           tagQuerySiblingBefore(selected_, ...)
-          rebuild_()
+          # rebuild_() # rebuild done within method
           invisible(self)
         },
         #' * `$replaceWith(...)`: Replace all selected elements with `...`. This
@@ -830,7 +830,7 @@ tagQuery_ <- function(
         replaceWith = function(...) {
           rebuild_()
           tagQuerySiblingReplaceWith(selected_, ...)
-          newTagQuery(list(), rebuild = TRUE)
+          newTagQuery(list(), rebuild = FALSE) # rebuild done within method
         },
         #' * `$remove(...)`: Remove all selected elements from the `tagQuery()`
         #' object. The selected elements is set to an empty set. A new
@@ -840,7 +840,7 @@ tagQuery_ <- function(
           rebuild_()
           tagQuerySiblingRemove(selected_)
           # Remove items from selected info
-          newTagQuery(list(), rebuild = TRUE)
+          newTagQuery(list(), rebuild = FALSE) # no rebuild necessary
         },
         ## end Adjust Siblings
 
@@ -1174,12 +1174,16 @@ tagQuerySiblingRemove <- function(els) {
 tagQuerySiblingAfter <- function(els, ...) {
   tagQueryMatchChildRev(els, function(elParent, el, childPos) {
     tagInsertChildren(elParent, after = childPos, ...)
+    # Make sure to rebuild the parent tag into tag envs
+    asTagEnv(elParent)
   })
 }
 # Add siblings before each el
 tagQuerySiblingBefore <- function(els, ...) {
   tagQueryMatchChildRev(els, function(elParent, el, childPos) {
     tagInsertChildren(elParent, after = childPos - 1, ...)
+    # Make sure to rebuild the parent tag into tag envs
+    asTagEnv(elParent)
   })
 }
 # Replace all `el` objects with `...`
@@ -1190,6 +1194,8 @@ tagQuerySiblingReplaceWith <- function(els, ...) {
     elParent$children[[childPos]] <- NULL
     # Replace with ... content where the child was
     tagInsertChildren(elParent, after = childPos - 1, ...)
+    # Make sure to rebuild the parent tag into tag envs
+    asTagEnv(elParent)
   })
 }
 

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -535,8 +535,8 @@ tagQuery <- function(tags) {
     wrapWithRootTag(tags)
   )
   # Select the top level tags
-  selected <- tagQueryFindReset(tags)
   tagQuery_(tags, selected)
+  selected <- tagQueryFindResetSelected(root)
 }
 
 #' @rdname tagQuery
@@ -686,11 +686,11 @@ tagQuery_ <- function(
           rebuild_()
           newTagQuery(newSelected)
         },
-        #' * `$reset()`: A new `tagQuery()` object will be created with the
+        #' * `$resetSelected()`: A new `tagQuery()` object will be created with the
         #' selected items set to the top level tag objects.
-        reset = function() {
+        resetSelected = function() {
           newTagQuery(
-            tagQueryFindReset(root)
+            tagQueryFindResetSelected(root)
           )
         },
         ## end Find
@@ -1311,9 +1311,8 @@ tagQueryClassToggle <- function(els, class) {
 }
 
 
-# Return a list of `root`.
-# This may change if root ends up becoming a list of elements
-tagQueryFindReset <- function(root) {
+# Return a list of `root$children`.
+tagQueryFindResetSelected <- function(root) {
   if (!isTagEnv(root)) {
     stop("`root` must be a tag environment")
   }

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -505,7 +505,7 @@ tagQuery <- function(tags) {
   # If `tags` is a list of tagEnvs...
   # * Make sure they share the same root element and
   # * Set the selected elements to `tags`
-  if (!isTagEnv(tags) && (is.list(tags) || isTagList(tags))) {
+  if (!isTag(tags) && (is.list(tags) || isTagList(tags))) {
     tagsIsTagEnv <- vapply(tags, isTagEnv, logical(1))
     if (any(tagsIsTagEnv)) {
       if (any(!tagsIsTagEnv)) {

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -174,7 +174,9 @@ selected elements given \code{fn(el, i)} returns \code{TRUE}. If \code{fn} is a 
 selector, then the selected elements will be filtered if they match
 the single-element CSS selector. A new \code{tagQuery()} object will be
 created with the selected items set to the filtered selected
-elements.
+elements. Remember, any alterations to the provided tag environments will persist
+in calling tag query object. If you need to make local changes, consider
+using \code{tagQuery(el)$selected()} to use standard tag objects.
 \item \verb{$reset()}: A new \code{tagQuery()} object will be created with the
 selected items set to the top level tag objects.
 }
@@ -239,9 +241,10 @@ the selected element's position within the selected elements. This
 argument order is different than jQuery's \verb{$().each()} as there is no
 concept of a \code{this} object inside the function execution. To stay
 consistent with other methods, the each of the selected tag
-environments will be given first, followed by the index position. Any
-alterations to the provided tag environments will persist in calling
-tag query object.
+environments will be given first, followed by the index position.
+Remember, any alterations to the provided tag environments will persist
+in calling tag query object. If you need to make local changes, consider
+using \code{tagQuery(el)$selected()} to use standard tag objects.
 }
 }
 

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -177,7 +177,7 @@ created with the selected items set to the filtered selected
 elements. Remember, any alterations to the provided tag environments will persist
 in calling tag query object. If you need to make local changes, consider
 using \code{tagQuery(el)$selected()} to use standard tag objects.
-\item \verb{$reset()}: A new \code{tagQuery()} object will be created with the
+\item \verb{$resetSelected()}: A new \code{tagQuery()} object will be created with the
 selected items set to the top level tag objects.
 }
 }

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -175,22 +175,22 @@ test_that("tagQuery()$find()", {
   )
   x <- x$find("a")
   expect_length(x$selected(), 2)
-  x <- x$reset()
+  x <- x$resetSelected()
 
   x <- x$find("a > p")
   expect_length(x$selected(), 1)
   expect_equal_tags(x$selected(), tagList(p("text2")))
-  x <- x$reset()
+  x <- x$resetSelected()
 
   x <- x$find("a > > p")
   expect_length(x$selected(), 1)
   expect_equal_tags(x$selected(), tagList(p("text1")))
-  x <- x$reset()
+  x <- x$resetSelected()
 
   x <- x$find("div > *")
   expect_length(x$selected(), 2)
   expect_equal_tags(x$selected(), tagList(a(span(p("text1"))), a(p("text2"))))
-  x <- x$reset()
+  x <- x$resetSelected()
 
   x <- x$find("div>>p")
   expect_length(x$selected(), 1)
@@ -258,7 +258,7 @@ test_that("tagQuery()$children() & tagQuery()$parent()", {
   expect_length(x$selected(), 1)
   secondDiv <- div(class = "b", span(class = "C", "3"), span(class = "D", "4"))
   expect_equal_tags(x$selected(), tagList(secondDiv))
-  x <- x$reset()$find("span")$parents(".b")
+  x <- x$resetSelected()$find("span")$parents(".b")
   expect_length(x$selected(), 1)
   expect_equal_tags(x$selected(), tagList(secondDiv))
 })
@@ -306,7 +306,7 @@ test_that("tagQuery()$parents() && tagQuery()$closest()", {
     )
   )
 
-  x <- x$reset()$find("span")$parents(".outer")
+  x <- x$resetSelected()$find("span")$parents(".outer")
   expect_length(x$selected(), 1)
 
   expect_equal_tags(
@@ -383,7 +383,7 @@ test_that("tagQuery()$hasClass(), $toggleClass(), $removeClass()", {
   expect_equal(x$hasClass("C"), FALSE)
   expect_equal(x$hasClass("A C"), FALSE)
 
-  x <- x$reset()$find("span")
+  x <- x$resetSelected()$find("span")
   expect_equal(x$hasClass("even"), c(FALSE, TRUE, FALSE, TRUE, FALSE))
   expect_equal(x$hasClass("odd"), c(TRUE, FALSE, TRUE, FALSE, TRUE))
   x$toggleClass("even odd")
@@ -534,7 +534,7 @@ test_that("tagQuery()$remove()", {
     div(span("a"), span("c"), span("e"))
   )
 
-  x <- x$reset()$find("span")
+  x <- x$resetSelected()$find("span")
   expect_length(x$selected(), 3)
   x <- x$remove()
   expect_equal_tags(

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -129,6 +129,24 @@ test_that("tagQuery() root values", {
   expect_error(tagQuery("a"), "initial set")
   expect_error(tagQuery(fakeJqueryDep), "initial set")
   expect_error(tagQuery(fakeTagFunction), "initial set")
+
+  x <- tagQuery(div(span(), a()))$find("span")
+  # expect_equal_tags(x$selected(), visibleTagList(span()))
+  # expect_equal_tags(x$selected(), visibleTagList(div(span(), a())))
+
+  # supply a tag query object
+  expect_equal_tags(tagQuery(x)$selected(), x$selected())
+  expect_equal_tags(tagQuery(x)$root(), x$root())
+
+  # supply a list of tag envs
+  tagEnvs <- list()
+  x$each(function(el, i) { tagEnvs[[length(tagEnvs) + 1]] <<- el})
+  expect_equal_tags(tagQuery(tagEnvs)$selected(), x$selected())
+  expect_equal_tags(tagQuery(tagEnvs)$root(), x$root())
+
+  # supply a single tag env
+  expect_equal_tags(tagQuery(tagEnvs[[1]])$selected(), x$selected())
+  expect_equal_tags(tagQuery(tagEnvs[[1]])$root(), x$root())
 })
 
 test_that("tagQuery() structure", {

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -674,28 +674,25 @@ test_that("rebuilding tag envs after inserting children is done", {
 
   expect_equal_tags(
     tagQuery(xTags)$find("div")$before(span())$root(),
-    visibleTagList(
+    # visibleTagList(
       div(span(), div(), span(), div())
-    )
+    # )
   )
 
   expect_equal_tags(
     tagQuery(xTags)$find("div")$replaceWith(span())$root(),
-    visibleTagList(
+    # visibleTagList(
       div(span(), span())
-    )
+    # )
   )
 
   expect_equal_tags(
     tagQuery(xTags)$find("div")$after(span())$root(),
-    visibleTagList(
+    # visibleTagList(
       div(div(), span(), div(), span())
-    )
+    # )
   )
 })
-
-
-
 
 
 

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -92,30 +92,31 @@ test_that("asTagEnv upgrades objects", {
 
 })
 
-test_that("asTagEnv finds cycles", {
-  x <- div(class = "test_class", span(class = "inner"))
-  xTagEnv <- asTagEnv(x)
-  expect_error(asTagEnv(xTagEnv), NA)
+## Cycles are not tested for anymore. Keeping in case they are brought back
+# test_that("asTagEnv finds cycles", {
+#   x <- div(class = "test_class", span(class = "inner"))
+#   xTagEnv <- asTagEnv(x)
+#   expect_error(asTagEnv(xTagEnv), NA)
 
-  testSpanEnv <- xTagEnv$children[[1]]
-  xTagEnv$children[[2]] <- testSpanEnv
-  xTagEnv$children[[3]] <- testSpanEnv
+#   testSpanEnv <- xTagEnv$children[[1]]
+#   xTagEnv$children[[2]] <- testSpanEnv
+#   xTagEnv$children[[3]] <- testSpanEnv
 
-  expect_error(asTagEnv(xTagEnv), "Duplicate tag environment found")
-  expect_equal_tags(
-    tagEnvToTags(xTagEnv),
-    div(
-      class = "test_class",
-      span(class = "inner"),
-      span(class = "inner"),
-      span(class = "inner")
-    )
-  )
+#   expect_error(asTagEnv(xTagEnv), "Duplicate tag environment found")
+#   expect_equal_tags(
+#     tagEnvToTags(xTagEnv),
+#     div(
+#       class = "test_class",
+#       span(class = "inner"),
+#       span(class = "inner"),
+#       span(class = "inner")
+#     )
+#   )
 
-  # make a cycle
-  testSpanEnv$children[[1]] <- xTagEnv
-  expect_error(asTagEnv(xTagEnv), "Duplicate tag environment")
-})
+#   # make a cycle
+#   testSpanEnv$children[[1]] <- xTagEnv
+#   expect_error(asTagEnv(xTagEnv), "Duplicate tag environment")
+# })
 
 
 

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -668,6 +668,31 @@ test_that("tagQuery() objects can not inherit from mixed objects", {
 
 
 
+test_that("rebuilding tag envs after inserting children is done", {
+  xTags <- div(div(), div())
+
+  expect_equal_tags(
+    tagQuery(xTags)$find("div")$before(span())$root(),
+    visibleTagList(
+      div(span(), div(), span(), div())
+    )
+  )
+
+  expect_equal_tags(
+    tagQuery(xTags)$find("div")$replaceWith(span())$root(),
+    visibleTagList(
+      div(span(), span())
+    )
+  )
+
+  expect_equal_tags(
+    tagQuery(xTags)$find("div")$after(span())$root(),
+    visibleTagList(
+      div(div(), span(), div(), span())
+    )
+  )
+})
+
 
 
 


### PR DESCRIPTION
Fixes #237 

* Remove cycle checking as it is slow and a very rare situation
* Do not rebuild unless it is possible something was altered. If the user needs to perform this themselves, they can call `tagQuery(x)$rebuild()`
* Reduce work done when adding a pseudo root tag
* Rename `$reset()` -> `$resetSelected()`