### PR TITLE
Allow tag query `$*Class()` methods to no-op on length 0 inputs

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -732,18 +732,18 @@ tagQuery_ <- function(
           tagQueryClassRemove(selected_, class)
           invisible(self)
         },
-        #' * `$hasClass(class)`: Determine whether the selected elements have a
-        #' given class. Returns a vector of logical values.
-        hasClass = function(class) {
-          rebuild_()
-          tagQueryClassHas(selected_, class)
-        },
         #' * `$toggleClass(class)`: If the a class value is missing, add it. If
         #' a  class value already exists, remove it.
         toggleClass = function(class) {
           rebuild_()
           tagQueryClassToggle(selected_, class)
           invisible(self)
+        },
+        #' * `$hasClass(class)`: Determine whether the selected elements have a
+        #' given class. Returns a vector of logical values.
+        hasClass = function(class) {
+          rebuild_()
+          tagQueryClassHas(selected_, class)
         },
 
         #' * `$addAttrs(...)`: Add named attributes to all selected children.
@@ -1289,6 +1289,11 @@ joinCssClass <- function(classes) {
 }
 # return list of logical values telling if the classes exists
 tagQueryClassHas <- function(els, class) {
+  # Quit early if class == NULL | character(0)
+  if (length(class) == 0) {
+    return(rep(FALSE, length(els)))
+  }
+
   classes <- getCssClass(class)
   unlist(
     tagQueryLapply(els, function(el) {
@@ -1305,6 +1310,9 @@ tagQueryClassHas <- function(els, class) {
 }
 # add classes that don't already exist
 tagQueryClassAdd <- function(els, class) {
+  # Quit early if class == NULL | character(0)
+  if (length(class) == 0) return()
+
   classes <- getCssClass(class)
   tagQueryWalk(els, function(el) {
     if (!isTagEnv(el)) return()
@@ -1316,6 +1324,9 @@ tagQueryClassAdd <- function(els, class) {
 }
 # remove classes that exist
 tagQueryClassRemove <- function(els, class) {
+  # Quit early if class == NULL | character(0)
+  if (length(class) == 0) return()
+
   classes <- getCssClass(class)
   tagQueryWalk(els, function(el) {
     if (!isTagEnv(el)) return()
@@ -1328,6 +1339,9 @@ tagQueryClassRemove <- function(els, class) {
 }
 # toggle class existence depending on if they already exist or not
 tagQueryClassToggle <- function(els, class) {
+  # Quit early if class == NULL | character(0)
+  if (length(class) == 0) return()
+
   classes <- getCssClass(class)
   tagQueryWalk(els, function(el) {
     if (!isTagEnv(el)) return()

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -732,18 +732,18 @@ tagQuery_ <- function(
           tagQueryClassRemove(selected_, class)
           invisible(self)
         },
+        #' * `$hasClass(class)`: Determine whether the selected elements have a
+        #' given class. Returns a vector of logical values.
+        hasClass = function(class) {
+          rebuild_()
+          tagQueryClassHas(selected_, class)
+        },
         #' * `$toggleClass(class)`: If the a class value is missing, add it. If
         #' a  class value already exists, remove it.
         toggleClass = function(class) {
           rebuild_()
           tagQueryClassToggle(selected_, class)
           invisible(self)
-        },
-        #' * `$hasClass(class)`: Determine whether the selected elements have a
-        #' given class. Returns a vector of logical values.
-        hasClass = function(class) {
-          rebuild_()
-          tagQueryClassHas(selected_, class)
         },
 
         #' * `$addAttrs(...)`: Add named attributes to all selected children.

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -186,10 +186,10 @@ selected items set to the top level tag objects.
 elements.
 \item \verb{$removeClass(class)}: Removes a set of class values from all of
 the selected elements.
-\item \verb{$toggleClass(class)}: If the a class value is missing, add it. If
-a  class value already exists, remove it.
 \item \verb{$hasClass(class)}: Determine whether the selected elements have a
 given class. Returns a vector of logical values.
+\item \verb{$toggleClass(class)}: If the a class value is missing, add it. If
+a  class value already exists, remove it.
 \item \verb{$addAttrs(...)}: Add named attributes to all selected children.
 Similar to \code{\link[=tagAppendAttributes]{tagAppendAttributes()}}.
 \item \verb{$removeAttrs(attrs)}: Removes the provided attributes in each of

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -186,10 +186,10 @@ selected items set to the top level tag objects.
 elements.
 \item \verb{$removeClass(class)}: Removes a set of class values from all of
 the selected elements.
-\item \verb{$hasClass(class)}: Determine whether the selected elements have a
-given class. Returns a vector of logical values.
 \item \verb{$toggleClass(class)}: If the a class value is missing, add it. If
 a  class value already exists, remove it.
+\item \verb{$hasClass(class)}: Determine whether the selected elements have a
+given class. Returns a vector of logical values.
 \item \verb{$addAttrs(...)}: Add named attributes to all selected children.
 Similar to \code{\link[=tagAppendAttributes]{tagAppendAttributes()}}.
 \item \verb{$removeAttrs(attrs)}: Removes the provided attributes in each of

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -358,6 +358,20 @@ test_that("tagQuery()$addClass()", {
 
   expect_equal(x$selected()[[1]]$attribs$class, "inner test-class")
 
+  expect_silent({
+    x$addClass(NULL)
+    x$removeClass(NULL)
+    x$toggleClass(NULL)
+    expect_equal(x$hasClass(NULL), c(FALSE))
+  })
+
+  expect_silent({
+    x$addClass(character(0))
+    x$removeClass(character(0))
+    x$toggleClass(character(0))
+    expect_equal(x$hasClass(character(0)), c(FALSE))
+  })
+
 })
 
 test_that("tagQuery()$hasClass(), $toggleClass(), $removeClass()", {
@@ -665,7 +679,6 @@ test_that("tagQuery() objects can not inherit from mixed objects", {
     "share the same root"
   )
 })
-
 
 
 


### PR DESCRIPTION
Fixes https://github.com/rstudio/htmltools/issues/216

Also works with `character(0)` inputs (or any length 0 inputs)

--------------

Moved the `$hasClass()` method down so that the method order is "add, empty-like, has", similar to the attr method on `tagQuery()`