### PR TITLE
`tagQuery()`: Remove `$rebuild()`; Rebuild the pseudoRoot tag on init.

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -847,15 +847,6 @@ tagQuery_ <- function(
         selectedTags = function() {
           tagQuerySelectedAsTags(selected_)
         },
-        #' * `$rebuild()`: Makes sure that all tags have been upgraded to tag
-        #' environments. Objects wrapped in `HTML()` will not be inspected or
-        #' altered. This method is internally called before each method executes
-        #' and after any alterations where standard tag objects could be
-        #' introduced into the tag structure.
-        rebuild = function() {
-          rebuild_()
-          self
-        },
         #' * `$print()`: Internal print method. Called by
         #' `print.shiny.tag.query()`
         print = function() {

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -497,7 +497,9 @@ tagQuery <- function(tags) {
   # Make a new tag query object from the root element of `tags`
   # * Set the selected to `list(tags)`
   if (isTagEnv(tags)) {
-    return(tagQuery_(findPseudoRootTag(tags), list(tags)))
+    # Rebuild pseudo root tag
+    pseudoRoot <- asTagEnv(
+      findPseudoRootTag(tags)
   }
 
   # If `tags` is a list of tagEnvs...
@@ -523,12 +525,11 @@ tagQuery <- function(tags) {
       walk(tags, function(el) {
         rootStack$push(findPseudoRootTag(el))
       })
-      roots <- rootStack$uniqueList()
       if (length(roots) != 1) {
         stop("All tag environments supplied to `tagQuery()` must share the same root element.")
       }
       return(
-        tagQuery_(roots[[1]], tags)
+        tagQuery_(pseudoRoot, tags)
       )
     }
   }

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -500,6 +500,10 @@ tagQuery <- function(tags) {
     # Rebuild pseudo root tag
     pseudoRoot <- asTagEnv(
       findPseudoRootTag(tags)
+    )
+    return(
+      tagQuery_(pseudoRoot, list(tags))
+    )
   }
 
   # If `tags` is a list of tagEnvs...
@@ -521,13 +525,16 @@ tagQuery <- function(tags) {
           "are not tag environments."
         )
       }
-      rootStack <- envirStackUnique()
+      pseudoRootStack <- envirStackUnique()
       walk(tags, function(el) {
-        rootStack$push(findPseudoRootTag(el))
+        pseudoRootStack$push(findPseudoRootTag(el))
       })
-      if (length(roots) != 1) {
+      pseudoRoots <- pseudoRootStack$uniqueList()
+      if (length(pseudoRoots) != 1) {
         stop("All tag environments supplied to `tagQuery()` must share the same root element.")
       }
+      # Rebuild pseudo root tag
+      pseudoRoot <- asTagEnv(pseudoRoots[[1]])
       return(
         tagQuery_(pseudoRoot, tags)
       )

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -734,7 +734,6 @@ tagQuery_ <- function(
         #' Similar to [`tagAppendAttributes()`].
         addAttrs = function(...) {
           tagQueryAttrsAdd(selected_, ...)
-          # no need to rebuild_(); already flattened in add attr function
           self
         },
         #' * `$removeAttrs(attrs)`: Removes the provided attributes in each of
@@ -762,7 +761,6 @@ tagQuery_ <- function(
         #' [`tagAppendChildren()`]
         append = function(...) {
           tagQueryChildrenAppend(selected_, ...)
-          rebuild_()
           self
         },
         #' * `$prepend(...)`: Add all `...` objects as children **before** any
@@ -770,7 +768,6 @@ tagQuery_ <- function(
         #' [`tagAppendChildren()`]
         prepend = function(...) {
           tagQueryChildrenPrepend(selected_, ...)
-          rebuild_()
           self
         },
         #' * `$empty()`: Remove all children in the selected elements. Use this
@@ -778,7 +775,6 @@ tagQuery_ <- function(
         #' elements' children.
         empty = function() {
           tagQueryChildrenEmpty(selected_)
-          # no need to rebuild_
           self
         },
         ## end Adjust Children
@@ -789,7 +785,6 @@ tagQuery_ <- function(
         #' selected elements.
         after = function(...) {
           tagQuerySiblingAfter(selected_, ...)
-          rebuild_()
           self
         },
         #' * `$before(...)`: Add all `...` objects as siblings before each of
@@ -1168,7 +1163,7 @@ tagQueryChildrenSet <- function(els, ...) {
   })
 }
 tagQueryChildrenEmpty <- function(els) {
-  # do not include any arguments.
+  # Do not include any arguments.
   # `dots_list()` returns an empty named list()
   tagQueryChildrenSet(els)
 }

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -255,11 +255,6 @@ standard \code{\link{tag}} objects. All root tags will be returned in a
 \item \verb{$selectedTags()}: Converts the selected tag environments
 to standard \code{\link{tag}} objects. The selected tags will be returned in a
 \code{\link[=tagList]{tagList()}}.
-\item \verb{$rebuild()}: Makes sure that all tags have been upgraded to tag
-environments. Objects wrapped in \code{HTML()} will not be inspected or
-altered. This method is internally called before each method executes
-and after any alterations where standard tag objects could be
-introduced into the tag structure.
 \item \verb{$print()}: Internal print method. Called by
 \code{print.shiny.tag.query()}
 }


### PR DESCRIPTION
Fixes https://github.com/rstudio/htmltools/issues/231