### PR TITLE
`tagQuery()`: Remove `$print()`

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -43,7 +43,7 @@ NULL
 # tagMutateAt <- function(x, cssSelector, fn) {
 #   tagQuery(tag)$find(cssSelector)$each(fn)$allTags()
 # }
-# tagFindAt <- function(x, css) {
+# tagFindAt <- function(x, cssSelector) {
 #   tagQuery(tag)$find(cssSelector)$selectedTags()
 # }
 
@@ -362,7 +362,31 @@ as.tags.shiny.tag.query <- function(x, ...) {
 }
 #' @export
 print.shiny.tag.query <- function(x, ...) {
-  x$print()
+  tagQ <- x
+  cat("`$allTags()`:\n")
+  allTags <- tagQ$allTags()
+  print(allTags)
+
+  selectedTags <- tagQ$selectedTags()
+
+  cat("\n`$selectedTags()`:")
+
+  if (length(selectedTags) == 0) {
+    cat(" (Empty selection)\n")
+  } else {
+    # Convert allTags to same style of object as selected tags
+    if (!isTagList(allTags)) allTags <- tagList(allTags)
+    allTags <- tagListPrintAsList(!!!allTags)
+
+    if (identical(allTags, selectedTags)) {
+      cat(" `$allTags()`\n")
+    } else {
+      cat("\n")
+      print(selectedTags)
+    }
+  }
+
+  invisible(x)
 }
 #' @export
 format.shiny.tag.query <- function(x, ...) {
@@ -860,13 +884,6 @@ tagQuery_ <- function(
         rebuild = function() {
           rebuild_()
           self
-        },
-        #' * `$print()`: Internal print method. Called by
-        #' `print.shiny.tag.query()`
-        print = function() {
-          # Allows `$print()` to know if there is a root el
-          tagQueryPrint(pseudoRoot, selected_)
-          invisible(self)
         }
       )
     )
@@ -982,30 +999,6 @@ tagListPrintAsList <- function(...) {
 tagQuerySelectedAsTags <- function(selected) {
   # return as a `tagList()` with a special attr that will cause it to print like a list
   tagListPrintAsList(!!!lapply(selected, tagEnvToTags))
-}
-
-tagQueryPrint <- function(pseudoRoot, selected) {
-  cat("Root:\n")
-  print(tagQueryTopLevelTags(pseudoRoot))
-
-  cat("\nSelected:")
-
-  if (length(selected) == 0) {
-    cat(" (Empty)\n")
-  } else {
-    if (identical(pseudoRoot$children, selected)) {
-      cat(" (Root)\n")
-    } else {
-      cat("\n")
-      selectedTags <- tagQuerySelectedAsTags(selected)
-      # add separator
-      walkI(selectedTags, function(selectedTag, i) {
-        cat("[[", i, "]]\n", sep = "")
-        print(selectedTag)
-      })
-    }
-  }
-
 }
 
 

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -260,8 +260,6 @@ environments. Objects wrapped in \code{HTML()} will not be inspected or
 altered. This method is internally called before each method executes
 and after any alterations where standard tag objects could be
 introduced into the tag structure.
-\item \verb{$print()}: Internal print method. Called by
-\code{print.shiny.tag.query()}
 }
 }
 }

--- a/tests/testthat/_snaps/tag-query.md
+++ b/tests/testthat/_snaps/tag-query.md
@@ -1,29 +1,30 @@
 # tagQuery() print method displays custom output for selected tags
 
-    Root:
+    `$allTags()`:
     <div>
       <span></span>
     </div>
     
-    Selected: (Root)
+    `$selectedTags()`: `$allTags()`
 
 ---
 
-    Root:
+    `$allTags()`:
     <div>
       <span></span>
     </div>
     
-    Selected:
+    `$selectedTags()`:
     [[1]]
     <span></span>
+    
 
 ---
 
-    Root:
+    `$allTags()`:
     <div>
       <span></span>
     </div>
     
-    Selected: (Empty)
+    `$selectedTags()`: (Empty selection)
 

--- a/tests/testthat/_snaps/tag-query.md
+++ b/tests/testthat/_snaps/tag-query.md
@@ -1,0 +1,29 @@
+# tagQuery() print method displays custom output for selected tags
+
+    Root:
+    <div>
+      <span></span>
+    </div>
+    
+    Selected: (Root)
+
+---
+
+    Root:
+    <div>
+      <span></span>
+    </div>
+    
+    Selected:
+    [[1]]
+    <span></span>
+
+---
+
+    Root:
+    <div>
+      <span></span>
+    </div>
+    
+    Selected: (Empty)
+

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -725,6 +725,22 @@ test_that("rebuilding tag envs after inserting children is done", {
 })
 
 
+test_that("tagQuery() print method displays custom output for selected tags", {
+  local_edition(3)
+
+  expect_snapshot_output(print(
+    tagQuery(div(span()))
+  ))
+
+  expect_snapshot_output(print(
+    tagQuery(div(span()))$find("span")
+  ))
+
+  expect_snapshot_output(print(
+    tagQuery(div(span()))$find("empty")
+  ))
+
+})
 
 
 


### PR DESCRIPTION
Fixes https://github.com/rstudio/htmltools/issues/231#issue-865002707