### PR TITLE
`tagQuery()`: Speed enhancements and consistent tag name order

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -177,6 +177,11 @@ envirStackUnique <- function() {
 
 
 
+# Copy all attributes that can be manually set
+# ?attr
+# Note that some attributes (namely ‘class’, ‘comment’, ‘dim’,
+# ‘dimnames’, ‘names’, ‘row.names’ and ‘tsp’) are treated specially
+# and have restrictions on the values which can be set.
 copyAttributes <- function(from, to) {
   attrVals <- attributes(from)
   attrNames <- names(attrVals)

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -320,11 +320,12 @@ tagEnvToTags_ <- function(x) {
         setdiff(xNames, c("name", "attribs", "children"))
       }
     )
-    # reorder values
+    # Reorder values
     x[] <- x[newNames]
-    # reorder names
+    # Reorder names
     names(x) <- newNames
-    # recurse through children
+
+    # Recurse through children
     x$children <- lapply(x$children, tagEnvToTags_)
   }
   x

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -263,9 +263,6 @@ asTagEnv_ <- function(x, parent = NULL) {
       x$envKey <- obj_address(x)
     }
 
-    # Make sure all attribs are unique
-    x$attribs <- flattenTagAttribs(x$attribs)
-
     # Recurse through children
     if (length(x$children) != 0) {
       # Possible optimization... name the children tags to the formatted values.

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -252,6 +252,13 @@ asTagEnv_ <- function(x, parent = NULL) {
       x$envKey <- obj_address(x)
     }
 
+    if (!is.character(x[["name"]])) {
+      stop("A tag environment has lost its `$name`. Did you remove it?")
+    }
+    # This alters the env, but these fields should exist!
+    if (is.null(x[["attribs"]])) x$attribs <- setNames(list(), character(0)) # Empty named list
+    if (is.null(x[["children"]])) x$children <- list()
+
     # Recurse through children
     if (length(x$children) != 0) {
       # Possible optimization... name the children tags to the formatted values.
@@ -292,12 +299,6 @@ tagEnvToTags_ <- function(x) {
   if (isTagEnv(x)) {
 
     xEl <- x
-    if (!is.character(xEl[["name"]])) {
-      stop("A tag environment has lost its `$name`. Did you remove it?")
-    }
-    # This alters the env, but these fields should exist!
-    if (is.null(xEl[["attribs"]])) xEl$attribs <- setNames(list(), character(0))
-    if (is.null(xEl[["children"]])) xEl$children <- list()
 
     # Pull the names `name`, `attribs`, and `children` first to match `tag()` name order
     envNames <- ls(envir = xEl, all.names = TRUE, sorted = FALSE)

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -259,15 +259,14 @@ asTagEnv_ <- function(x, parent = NULL) {
       # Simplify the structures by flatting the tags
       # Does NOT recurse to grand-children etc.
       children <- flattenTagsRaw(x$children)
-      envChildren <- children
       # Use a `for-loop` over `lapply` to avoid `lapply` overhead
       for (i in seq_along(children)) {
         child <- children[[i]]
         if (!is.null(child)) {
-          envChildren[[i]] <- asTagEnv_(child, parent = x)
+          children[[i]] <- asTagEnv_(child, parent = x)
         }
       }
-      x$children <- envChildren
+      x$children <- children
     }
   }
   x
@@ -296,7 +295,7 @@ tagEnvToTags_ <- function(x) {
     if (is.null(xEl[["children"]])) xEl$children <- list()
 
     # Pull the names `name`, `attribs`, and `children` first to match `tag()` name order
-    envNames <- ls(envir = xEl, all.names = TRUE)
+    envNames <- ls(envir = xEl, all.names = TRUE, sorted = FALSE)
     newNames <- c(
       "name", "attribs", "children",
       if (length(envNames) > 5) {
@@ -312,15 +311,14 @@ tagEnvToTags_ <- function(x) {
 
     # Recurse through children
     children <- x$children
-    tagChildren <- children
     # Use a `for-loop` over `lapply` to avoid overhead
     for (i in seq_along(children)) {
       child <- children[[i]]
       if (!is.null(child)) {
-        tagChildren[[i]] <- tagEnvToTags_(child)
+        children[[i]] <- tagEnvToTags_(child)
       }
     }
-    x$children <- tagChildren
+    x$children <- children
   }
   x
 }

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1285,6 +1285,10 @@ tagQueryClassHas <- function(els, class) {
     use.names = FALSE
   )
 }
+removeClassVals <- function(classes, classesToRemove) {
+  # removes the call to `unique()` with `setdiff`
+  classes[match(classes, classesToRemove, 0L) == 0L]
+}
 # add classes that don't already exist
 tagQueryClassAdd <- function(els, class) {
   # Quit early if class == NULL | character(0)
@@ -1295,7 +1299,7 @@ tagQueryClassAdd <- function(els, class) {
     if (!isTagEnv(el)) return()
     classVal <- el$attribs$class %||% ""
     elClasses <- splitCssClass(classVal)
-    newClasses <- c(elClasses, setdiff(classes, elClasses))
+    newClasses <- c(elClasses, removeClassVals(classes, elClasses))
     el$attribs$class <- joinCssClass(newClasses)
   })
 }
@@ -1310,7 +1314,7 @@ tagQueryClassRemove <- function(els, class) {
     classVal <- el$attribs$class
     if (is.null(classVal)) return()
     elClasses <- splitCssClass(classVal)
-    newClasses <- setdiff(elClasses, classes)
+    newClasses <- removeClassVals(elClasses, classes)
     el$attribs$class <- joinCssClass(newClasses)
   })
 }
@@ -1326,7 +1330,7 @@ tagQueryClassToggle <- function(els, class) {
     elClasses <- splitCssClass(classVal)
     hasClass <- (classes %in% elClasses)
     if (any(hasClass)) {
-      elClasses <- setdiff(elClasses, classes)
+      elClasses <- removeClassVals(elClasses, classes)
     }
     if (any(!hasClass)) {
       elClasses <- c(elClasses, classes[!hasClass])

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -303,7 +303,6 @@ tagEnvToTags_ <- function(x) {
     # undo parent env and key
     x$parent <- NULL
     x$envKey <- NULL
-    xNames <- names(x)
 
     # Reorder the names to match a typical tag() structure that has `name`, `attribs`, and `children` first
     # Avoid calling `setdiff()` if possible (it is slow).
@@ -313,6 +312,7 @@ tagEnvToTags_ <- function(x) {
     if (is.null(x[["attribs"]])) x$attribs <- setNames(list(), character(0))
     if (is.null(x[["children"]])) x$children <- list()
 
+    xNames <- names(x)
     newNames <- c(
       "name", "attribs", "children",
       if (

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -315,17 +315,17 @@ tagEnvToTags_ <- function(x) {
     xNames <- names(x)
     newNames <- c(
       "name", "attribs", "children",
-      if (
-        length(xNames) > 3
-      ) {
+      if (length(xNames) > 3) {
         setdiff(xNames, c("name", "attribs", "children"))
       }
     )
-    # Need to preserve attributes. Must move values in two steps.
-    # Reorder values
-    x[] <- x[newNames]
-    # Reorder names
-    names(x) <- newNames
+    if (!identical(xNames, newNames)) {
+      # Need to preserve attributes. Must move values in two steps.
+      # Reorder values
+      x[] <- x[newNames]
+      # Reorder names
+      names(x) <- newNames
+    }
 
     # Recurse through children
     x$children <- lapply(x$children, tagEnvToTags_)

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -305,21 +305,23 @@ tagEnvToTags_ <- function(x) {
     x$envKey <- NULL
     xNames <- names(x)
 
-    # Reorder the names to match a typical tag() structure that has `name` first
+    # Reorder the names to match a typical tag() structure that has `name`, `attribs`, and `children` first
     # Avoid calling `setdiff()` if possible (it is slow).
+    if (!is.character(x[["name"]])) {
+      stop("A tag environment has lost its `$name`. Did you remove it?")
+    }
+    if (is.null(x[["attribs"]])) x$attribs <- setNames(list(), character(0))
+    if (is.null(x[["children"]])) x$children <- list()
+
     newNames <- c(
-      if (hasName <- which(xNames == "name") > 0) "name",
-      if (hasAttrib <- which(xNames == "attribs") > 0) "attribs",
-      if (hasChildren <- which(xNames == "children") > 0) "children",
+      "name", "attribs", "children",
       if (
-        (!hasName) ||
-        (!hasAttrib) ||
-        (!hasChildren) ||
         length(xNames) > 3
       ) {
         setdiff(xNames, c("name", "attribs", "children"))
       }
     )
+    # Need to preserve attributes. Must move values in two steps.
     # Reorder values
     x[] <- x[newNames]
     # Reorder names

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -303,6 +303,27 @@ tagEnvToTags_ <- function(x) {
     # undo parent env and key
     x$parent <- NULL
     x$envKey <- NULL
+    xNames <- names(x)
+
+    # Reorder the names to match a typical tag() structure that has `name` first
+    # Avoid calling `setdiff()` if possible (it is slow).
+    newNames <- c(
+      if (hasName <- which(xNames == "name") > 0) "name",
+      if (hasAttrib <- which(xNames == "attribs") > 0) "attribs",
+      if (hasChildren <- which(xNames == "children") > 0) "children",
+      if (
+        (!hasName) ||
+        (!hasAttrib) ||
+        (!hasChildren) ||
+        length(xNames) > 3
+      ) {
+        setdiff(xNames, c("name", "attribs", "children"))
+      }
+    )
+    # reorder values
+    x[] <- x[newNames]
+    # reorder names
+    names(x) <- newNames
     # recurse through children
     x$children <- lapply(x$children, tagEnvToTags_)
   }

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -177,31 +177,29 @@ envirStackUnique <- function() {
 
 
 
+copyAttributes <- function(from, to) {
+  attrVals <- attributes(from)
+  attrNames <- names(attrVals)
+  for (i in seq_along(attrNames)) {
+    attrName <- attrNames[i]
+    switch(
+      attrName,
+      class = , comment =, dim =, dimnames =, names =, row.names =, tsp = NULL,
+      {
+        # Copy over the attribute
+        attr(to, attrName) <- attrVals[[i]]
+      }
+    )
+  }
 
-
-# Retrieve all attributes that can be manually set
-# ?attr
-# Note that some attributes (namely ‘class’, ‘comment’, ‘dim’,
-# ‘dimnames’, ‘names’, ‘row.names’ and ‘tsp’) are treated specially
-# and have restrictions on the values which can be set.
-safeAttrValues <- function(x) {
-  badElAttrs <- c("class", "comment", "dim", "dimnames", "names", "row.names", "tsp")
-  attrVals <- attributes(x)
-  attrVals[badElAttrs] <- NULL
-  attrVals
+  to
 }
 
 # Convert a list to an environment and keep class and attribute information
 safeListToEnv <- function(x, classToAdd = NULL) {
   xList <- x
-
   ret <- list2env(xList, new.env(parent = emptyenv()))
-
-  attrVals <- safeAttrValues(xList)
-  walk2(names(attrVals), attrVals, function(attrName, attrValue) {
-    attr(ret, attrName) <<- attrValue
-  })
-
+  ret <- copyAttributes(from = xList, to = ret)
   oldClass(ret) <- c(classToAdd, oldClass(xList))
   ret
 }

--- a/tests/testthat/helper-tags.R
+++ b/tests/testthat/helper-tags.R
@@ -1,0 +1,26 @@
+
+# Needed to compare tags that go from lists to envs and back to lists.
+expect_equal_tags <- function(x, y) {
+  expect_equal_tags_ <- function(x, y) {
+    if (isTag(x)) {
+      expect_true(isTag(y))
+      expect_equal(x$parent, NULL)
+      expect_equal(y$parent, NULL)
+      expect_equal(x$envKey, NULL)
+      expect_equal(y$envKey, NULL)
+      # Recurse through children
+      expect_equal_tags_(x$children, y$children)
+    } else if (is.list(x)) {
+      expect_true(is.list(y))
+      expect_equal(length(x), length(y))
+      Map(x, y, f = expect_equal_tags_)
+    } else {
+      # no tags to recurse
+    }
+  }
+
+  # Should be fully equal.
+  expect_equal(x, y)
+  # Do custom checks to make sure tagQuery undid any internal changes
+  expect_equal_tags_(x, y)
+}

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -704,35 +704,54 @@ test_that("tagQuery() allows for tags with extra top level items and will preser
   html <- c(list(first = TRUE), html)
   class(html) <- "shiny.tag"
 
-  expect_error(
-    tagQuery(html)$each(function(el, i) {
-      el$name <- NULL
-    })$allTags(),
-    "lost its `$name`", fixed = TRUE
-  )
+  # Test different removal types: setting the value to NULL and removing the value from the envir completely.
+  for (removeType in c("set", "rm")) {
+    expect_error(
+      tagQuery(html)$each(function(el, i) {
+        switch(removeType,
+          set = {
+            el$name <- NULL
+          },
+          rm = {
+            rm(list = "name", envir = el)
+          }
+        )
+      })$allTags(),
+      "lost its `$name`", fixed = TRUE
+    )
 
-  for (missing_key in c("__not_a_match__", "attribs", "children")) {
-    htmlQ <- tagQuery(html)
-    if (missing_key %in% names(html)) {
-      htmlQ$each(function(el, i) {
-        el[[missing_key]] <- NULL
-      })
+    for (missing_key in c("__not_a_match__", "attribs", "children")) {
+      htmlQ <- tagQuery(html)
+      if (missing_key %in% names(html)) {
+        htmlQ$each(function(el, i) {
+          switch(removeType,
+            set = {
+              el[[missing_key]] <- NULL
+            },
+            rm = {
+              rm(list = missing_key, envir = el)
+            }
+          )
+          el[[missing_key]] <- NULL
+        })
+      }
+      htmlPostQ <- htmlQ$allTags()
+      html_out <- html
+      if (missing_key == "attribs") html_out$attribs <- dots_list()
+      if (missing_key == "children") html_out$children <- list()
+      # expect first three names to be standard tag names
+      expect_equal(names(htmlPostQ)[1:3], names(div()))
+
+      # expect all other names to be included somewhere
+      expect_setequal(names(htmlPostQ), names(html_out))
+
+      # If done in the same order, it should be equal
+      back_to_orig <- htmlPostQ[names(html_out)]
+      class(back_to_orig) <- "shiny.tag"
+      expect_equal(back_to_orig, html_out)
     }
-    htmlPostQ <- htmlQ$allTags()
-    html_out <- html
-    if (missing_key == "attribs") html_out$attribs <- dots_list()
-    if (missing_key == "children") html_out$children <- list()
-    # expect first three names to be standard tag names
-    expect_equal(names(htmlPostQ)[1:3], names(div()))
-
-    # expect all other names to be included somewhere
-    expect_setequal(names(htmlPostQ), names(html_out))
-
-    # If done in the same order, it should be equal
-    back_to_orig <- htmlPostQ[names(html_out)]
-    class(back_to_orig) <- "shiny.tag"
-    expect_equal(back_to_orig, html_out)
   }
+
 })
 
 

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -729,16 +729,13 @@ test_that("tagQuery() allows for tags with extra top level items and will preser
     expect_equal(names(htmlPostQ)[1:3], names(div()))
 
     # expect all other names to be included somewhere
-    # browser()
     expect_setequal(names(htmlPostQ), names(html_out))
 
     # If done in the same order, it should be equal
-    back_to_orig <- htmlPostQ[names(html_out)]; class(back_to_orig) <- "shiny.tag"
+    back_to_orig <- htmlPostQ[names(html_out)]
+    class(back_to_orig) <- "shiny.tag"
     expect_equal(back_to_orig, html_out)
   }
-
-
-
 })
 
 

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -701,6 +701,45 @@ test_that("tagQuery() print method displays custom output for selected tags", {
 })
 
 
+test_that("tagQuery() allows for tags with extra top level items and will preserve them", {
+  html <- div(span())
+  html$test <- "extra"
+  html <- c(list(first = TRUE), html)
+  class(html) <- "shiny.tag"
+
+  expect_error(
+    tagQuery(html)$each(function(el, i) {
+      el$name <- NULL
+    })$allTags(),
+    "lost its `$name`", fixed = TRUE
+  )
+
+  for (missing_key in c("__not_a_match__", "attribs", "children")) {
+    htmlQ <- tagQuery(html)
+    if (missing_key %in% names(html)) {
+      htmlQ$each(function(el, i) {
+        el[[missing_key]] <- NULL
+      })
+    }
+    htmlPostQ <- htmlQ$allTags()
+    html_out <- html
+    if (missing_key == "attribs") html_out$attribs <- dots_list()
+    if (missing_key == "children") html_out$children <- list()
+    # expect first three names to be standard tag names
+    expect_equal(names(htmlPostQ)[1:3], names(div()))
+
+    # expect all other names to be included somewhere
+    # browser()
+    expect_setequal(names(htmlPostQ), names(html_out))
+
+    # If done in the same order, it should be equal
+    back_to_orig <- htmlPostQ[names(html_out)]; class(back_to_orig) <- "shiny.tag"
+    expect_equal(back_to_orig, html_out)
+  }
+
+
+
+})
 
 
 

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -2,48 +2,6 @@
 fakeJqueryDep <- htmlDependency("jquery", "1.11.3", c(href="shared"), script = "jquery.js")
 fakeTagFunction <- tagFunction(function(){ span("inner span") })
 
-sortInternalNames <- function(x) {
-  if (is.list(x) && is_named(x)) {
-    x[order(names(x))]
-  } else {
-    x
-  }
-}
-
-# Needed to compare tags that go from lists to envs and back to lists.
-# The names are alpha sorted in the final tag object
-expect_equal_tags <- function(x, y) {
-  if (isTag(x)) {
-    expect_true(isTag(y))
-    expect_equal(x$parent, NULL)
-    expect_equal(y$parent, NULL)
-    expect_equal(x$envKey, NULL)
-    expect_equal(y$envKey, NULL)
-    x <- sortInternalNames(x)
-    y <- sortInternalNames(y)
-    # compare everything but the children
-    expect_equal(
-      x[setdiff(names(x), "children")],
-      y[setdiff(names(y), "children")]
-    )
-    expect_equal_tags(x$children, y$children)
-  } else if (is.list(x)) {
-    if (isTagList(x)) {
-      expect_true(isTagList(y))
-      expect_equal(
-        attr(x, "print.as.list", exact = TRUE),
-        attr(y, "print.as.list", exact = TRUE)
-      )
-    } else {
-      expect_true(is.list(y))
-    }
-    expect_equal(length(x), length(y))
-    expect_equal(names2(x), names2(y))
-    Map(x, y, f = expect_equal_tags)
-  } else {
-    expect_equal(x, y)
-  }
-}
 
 test_that("safeListToEnv and safeEnvToList undo each other", {
 
@@ -107,7 +65,7 @@ test_that("asTagEnv upgrades objects", {
 #   xTagEnv$children[[3]] <- testSpanEnv
 
 #   expect_error(asTagEnv(xTagEnv), "Duplicate tag environment found")
-#   expect_equal_tags(
+#   expect_equal(
 #     tagEnvToTags(xTagEnv),
 #     div(
 #       class = "test_class",
@@ -135,22 +93,22 @@ test_that("tagQuery() root values", {
   expect_error(tagQuery(fakeTagFunction), "initial set")
 
   x <- tagQuery(div(span(), a()))$find("span")
-  # expect_equal_tags(x$selectedTags(), tagListPrintAsList(span()))
-  # expect_equal_tags(x$selectedTags(), tagListPrintAsList(div(span(), a())))
+  # expect_equal(x$selectedTags(), tagListPrintAsList(span()))
+  # expect_equal(x$selectedTags(), tagListPrintAsList(div(span(), a())))
 
   # supply a tag query object
-  expect_equal_tags(tagQuery(x)$selectedTags(), x$selectedTags())
-  expect_equal_tags(tagQuery(x)$allTags(), x$allTags())
+  expect_equal(tagQuery(x)$selectedTags(), x$selectedTags())
+  expect_equal(tagQuery(x)$allTags(), x$allTags())
 
   # supply a list of tag envs
   tagEnvs <- list()
   x$each(function(el, i) { tagEnvs[[length(tagEnvs) + 1]] <<- el})
-  expect_equal_tags(tagQuery(tagEnvs)$selectedTags(), x$selectedTags())
-  expect_equal_tags(tagQuery(tagEnvs)$allTags(), x$allTags())
+  expect_equal(tagQuery(tagEnvs)$selectedTags(), x$selectedTags())
+  expect_equal(tagQuery(tagEnvs)$allTags(), x$allTags())
 
   # supply a single tag env
-  expect_equal_tags(tagQuery(tagEnvs[[1]])$selectedTags(), x$selectedTags())
-  expect_equal_tags(tagQuery(tagEnvs[[1]])$allTags(), x$allTags())
+  expect_equal(tagQuery(tagEnvs[[1]])$selectedTags(), x$selectedTags())
+  expect_equal(tagQuery(tagEnvs[[1]])$allTags(), x$allTags())
 })
 
 test_that("tagQuery() structure", {
@@ -174,7 +132,7 @@ test_that("tagQuery()$find()", {
 
   x <- x$find("span")
   expect_length(x$selectedTags(), 2)
-  expect_equal_tags(
+  expect_equal(
     x$selectedTags(),
     tagListPrintAsList(span("a"), span("b"))
   )
@@ -201,22 +159,22 @@ test_that("tagQuery()$find()", {
 
   x <- x$find("a > p")
   expect_length(x$selectedTags(), 1)
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(p("text2")))
+  expect_equal(x$selectedTags(), tagListPrintAsList(p("text2")))
   x <- x$resetSelected()
 
   x <- x$find("a > > p")
   expect_length(x$selectedTags(), 1)
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(p("text1")))
+  expect_equal(x$selectedTags(), tagListPrintAsList(p("text1")))
   x <- x$resetSelected()
 
   x <- x$find("div > *")
   expect_length(x$selectedTags(), 2)
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(a(span(p("text1"))), a(p("text2"))))
+  expect_equal(x$selectedTags(), tagListPrintAsList(a(span(p("text1"))), a(p("text2"))))
   x <- x$resetSelected()
 
   x <- x$find("div>>p")
   expect_length(x$selectedTags(), 1)
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(p("text2")))
+  expect_equal(x$selectedTags(), tagListPrintAsList(p("text2")))
 })
 
 test_that("tagQuery()$filter()", {
@@ -239,7 +197,7 @@ test_that("tagQuery()$filter()", {
   })
   expect_length(x$selectedTags(), 1)
 
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(span(4)))
+  expect_equal(x$selectedTags(), tagListPrintAsList(span(4)))
 })
 
 test_that("tagQuery()$children() & tagQuery()$parent()", {
@@ -260,7 +218,7 @@ test_that("tagQuery()$children() & tagQuery()$parent()", {
 
   x <- x$children()
   expect_length(x$selectedTags(), 4)
-  expect_equal_tags(
+  expect_equal(
     x$selectedTags(),
     tagListPrintAsList(
       span(class = "A", "1"),
@@ -279,10 +237,10 @@ test_that("tagQuery()$children() & tagQuery()$parent()", {
   x <- x$parent()
   expect_length(x$selectedTags(), 1)
   secondDiv <- div(class = "b", span(class = "C", "3"), span(class = "D", "4"))
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(secondDiv))
+  expect_equal(x$selectedTags(), tagListPrintAsList(secondDiv))
   x <- x$resetSelected()$find("span")$parents(".b")
   expect_length(x$selectedTags(), 1)
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(secondDiv))
+  expect_equal(x$selectedTags(), tagListPrintAsList(secondDiv))
 })
 
 
@@ -319,7 +277,7 @@ test_that("tagQuery()$parents() && tagQuery()$closest()", {
   x <- x$find("span")$parents()
   expect_length(x$selectedTags(), 3)
 
-  expect_equal_tags(
+  expect_equal(
     x$selectedTags(),
     tagListPrintAsList(
       xTags$children[[1]]$children[[1]],
@@ -331,7 +289,7 @@ test_that("tagQuery()$parents() && tagQuery()$closest()", {
   x <- x$resetSelected()$find("span")$parents(".outer")
   expect_length(x$selectedTags(), 1)
 
-  expect_equal_tags(
+  expect_equal(
     x$selectedTags(),
     tagListPrintAsList(xTags)
   )
@@ -470,7 +428,7 @@ test_that("tagQuery()$append()", {
 
   newa <- span("a")
   x$append(newa)
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div(span("child"), newa)
   )
@@ -479,7 +437,7 @@ test_that("tagQuery()$append()", {
   new2 <- div("new2")
   x$append(new1, new2)
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div(span("child"), newa, new1, new2)
   )
@@ -491,7 +449,7 @@ test_that("tagQuery()$prepend()", {
 
   newa <- span("a")
   x$prepend(newa)
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div(newa, span("child"))
   )
@@ -500,7 +458,7 @@ test_that("tagQuery()$prepend()", {
   new2 <- div("new2")
   x$prepend(new1, new2)
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div(new1, new2, newa, span("child"))
   )
@@ -521,7 +479,7 @@ test_that("tagQuery()$each()", {
     "ignored"
   })
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div(span("A"), h1("title"), span("B"))
   )
@@ -546,7 +504,7 @@ test_that("tagQuery()$allTags() & tagQuery()$rebuild()", {
   # make sure the last child is a tag env (not a standard tag)
   expect_false(isTagEnv(lastChild))
   # make sure it equals what was manually added
-  expect_equal_tags(lastChild, div("test"))
+  expect_equal(lastChild, div("test"))
 })
 
 
@@ -565,7 +523,7 @@ test_that("tagQuery()$remove()", {
   x <- x$filter(".A")$remove()
   expect_length(x$selectedTags(), 0)
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div(span("a"), span("c"), span("e"))
   )
@@ -573,7 +531,7 @@ test_that("tagQuery()$remove()", {
   x <- x$resetSelected()$find("span")
   expect_length(x$selectedTags(), 3)
   x <- x$remove()
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     div()
   )
@@ -586,7 +544,7 @@ test_that("tagQuery()$after()", {
 
   newa <- span("a")
   x$after(newa)
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     tagList(xTags, newa)
   )
@@ -595,7 +553,7 @@ test_that("tagQuery()$after()", {
   new2 <- div("new2")
   x$after(new1, new2)
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     tagList(xTags, new1, new2, newa)
   )
@@ -607,7 +565,7 @@ test_that("tagQuery()$before()", {
 
   newa <- span("a")
   x$before(newa)
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     tagList(newa, xTags)
   )
@@ -616,7 +574,7 @@ test_that("tagQuery()$before()", {
   new2 <- div("new2")
   x$before(new1, new2)
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     tagList(newa, new1, new2, xTags)
   )
@@ -634,7 +592,7 @@ test_that("tagQuery(x)$allTags()", {
 
   x <- tagQuery(xTags)
 
-  expect_equal_tags(
+  expect_equal(
     x$allTags(),
     tagList(!!!xTags)
   )
@@ -659,15 +617,15 @@ test_that("tagQuery() objects inherit from each other objects", {
 
   expected <- div(span(class="extra", "text"))
 
-  expect_equal_tags(x$selectedTags(), tagListPrintAsList(!!!expected$children))
-  expect_equal_tags(y$selectedTags(), tagListPrintAsList(!!!expected$children))
-  expect_equal_tags(z$selectedTags(), tagListPrintAsList(!!!expected$children))
-  expect_equal_tags(w$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal(x$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal(y$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal(z$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal(w$selectedTags(), tagListPrintAsList(!!!expected$children))
 
-  expect_equal_tags(x$allTags(), expected)
-  expect_equal_tags(y$allTags(), expected)
-  expect_equal_tags(z$allTags(), expected)
-  expect_equal_tags(w$allTags(), expected)
+  expect_equal(x$allTags(), expected)
+  expect_equal(y$allTags(), expected)
+  expect_equal(z$allTags(), expected)
+  expect_equal(w$allTags(), expected)
 })
 
 
@@ -708,17 +666,17 @@ test_that("tagQuery() objects can not inherit from mixed objects", {
 test_that("rebuilding tag envs after inserting children is done", {
   xTags <- div(div(), div())
 
-  expect_equal_tags(
+  expect_equal(
     tagQuery(xTags)$find("div")$before(span())$allTags(),
     div(span(), div(), span(), div())
   )
 
-  expect_equal_tags(
+  expect_equal(
     tagQuery(xTags)$find("div")$replaceWith(span())$allTags(),
     div(span(), span())
   )
 
-  expect_equal_tags(
+  expect_equal(
     tagQuery(xTags)$find("div")$after(span())$allTags(),
     div(div(), span(), div(), span())
   )

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -93,22 +93,22 @@ test_that("tagQuery() root values", {
   expect_error(tagQuery(fakeTagFunction), "initial set")
 
   x <- tagQuery(div(span(), a()))$find("span")
-  # expect_equal(x$selectedTags(), tagListPrintAsList(span()))
-  # expect_equal(x$selectedTags(), tagListPrintAsList(div(span(), a())))
+  # expect_equal_tags(x$selectedTags(), tagListPrintAsList(span()))
+  # expect_equal_tags(x$selectedTags(), tagListPrintAsList(div(span(), a())))
 
   # supply a tag query object
-  expect_equal(tagQuery(x)$selectedTags(), x$selectedTags())
-  expect_equal(tagQuery(x)$allTags(), x$allTags())
+  expect_equal_tags(tagQuery(x)$selectedTags(), x$selectedTags())
+  expect_equal_tags(tagQuery(x)$allTags(), x$allTags())
 
   # supply a list of tag envs
   tagEnvs <- list()
   x$each(function(el, i) { tagEnvs[[length(tagEnvs) + 1]] <<- el})
-  expect_equal(tagQuery(tagEnvs)$selectedTags(), x$selectedTags())
-  expect_equal(tagQuery(tagEnvs)$allTags(), x$allTags())
+  expect_equal_tags(tagQuery(tagEnvs)$selectedTags(), x$selectedTags())
+  expect_equal_tags(tagQuery(tagEnvs)$allTags(), x$allTags())
 
   # supply a single tag env
-  expect_equal(tagQuery(tagEnvs[[1]])$selectedTags(), x$selectedTags())
-  expect_equal(tagQuery(tagEnvs[[1]])$allTags(), x$allTags())
+  expect_equal_tags(tagQuery(tagEnvs[[1]])$selectedTags(), x$selectedTags())
+  expect_equal_tags(tagQuery(tagEnvs[[1]])$allTags(), x$allTags())
 })
 
 test_that("tagQuery() structure", {
@@ -124,7 +124,7 @@ test_that("tagQuery()$find()", {
   # Make sure the found elements do not persist
   newX <- x$find("span")
   expect_failure(
-    expect_equal(
+    expect_equal_tags(
       x$selectedTags(),
       newX$selectedTags()
     )
@@ -132,7 +132,7 @@ test_that("tagQuery()$find()", {
 
   x <- x$find("span")
   expect_length(x$selectedTags(), 2)
-  expect_equal(
+  expect_equal_tags(
     x$selectedTags(),
     tagListPrintAsList(span("a"), span("b"))
   )
@@ -159,22 +159,22 @@ test_that("tagQuery()$find()", {
 
   x <- x$find("a > p")
   expect_length(x$selectedTags(), 1)
-  expect_equal(x$selectedTags(), tagListPrintAsList(p("text2")))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(p("text2")))
   x <- x$resetSelected()
 
   x <- x$find("a > > p")
   expect_length(x$selectedTags(), 1)
-  expect_equal(x$selectedTags(), tagListPrintAsList(p("text1")))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(p("text1")))
   x <- x$resetSelected()
 
   x <- x$find("div > *")
   expect_length(x$selectedTags(), 2)
-  expect_equal(x$selectedTags(), tagListPrintAsList(a(span(p("text1"))), a(p("text2"))))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(a(span(p("text1"))), a(p("text2"))))
   x <- x$resetSelected()
 
   x <- x$find("div>>p")
   expect_length(x$selectedTags(), 1)
-  expect_equal(x$selectedTags(), tagListPrintAsList(p("text2")))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(p("text2")))
 })
 
 test_that("tagQuery()$filter()", {
@@ -197,7 +197,7 @@ test_that("tagQuery()$filter()", {
   })
   expect_length(x$selectedTags(), 1)
 
-  expect_equal(x$selectedTags(), tagListPrintAsList(span(4)))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(span(4)))
 })
 
 test_that("tagQuery()$children() & tagQuery()$parent()", {
@@ -218,7 +218,7 @@ test_that("tagQuery()$children() & tagQuery()$parent()", {
 
   x <- x$children()
   expect_length(x$selectedTags(), 4)
-  expect_equal(
+  expect_equal_tags(
     x$selectedTags(),
     tagListPrintAsList(
       span(class = "A", "1"),
@@ -237,10 +237,10 @@ test_that("tagQuery()$children() & tagQuery()$parent()", {
   x <- x$parent()
   expect_length(x$selectedTags(), 1)
   secondDiv <- div(class = "b", span(class = "C", "3"), span(class = "D", "4"))
-  expect_equal(x$selectedTags(), tagListPrintAsList(secondDiv))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(secondDiv))
   x <- x$resetSelected()$find("span")$parents(".b")
   expect_length(x$selectedTags(), 1)
-  expect_equal(x$selectedTags(), tagListPrintAsList(secondDiv))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(secondDiv))
 })
 
 
@@ -266,18 +266,18 @@ test_that("tagQuery()$parents() && tagQuery()$closest()", {
   xc <- x$find("span")$closest()
   expect_length(xc$selectedTags(), 5)
   xc$each(function(el, i) {
-    expect_equal(el$name, "span")
+    expect_equal_tags(el$name, "span")
   })
 
   xp <- x$find("span")$parents("div")
   expect_length(xp$selectedTags(), 2)
-  expect_equal(xp$hasClass("outer"), c(FALSE, TRUE))
-  expect_equal(xp$hasClass("inner"), c(TRUE, FALSE))
+  expect_equal_tags(xp$hasClass("outer"), c(FALSE, TRUE))
+  expect_equal_tags(xp$hasClass("inner"), c(TRUE, FALSE))
 
   x <- x$find("span")$parents()
   expect_length(x$selectedTags(), 3)
 
-  expect_equal(
+  expect_equal_tags(
     x$selectedTags(),
     tagListPrintAsList(
       xTags$children[[1]]$children[[1]],
@@ -289,7 +289,7 @@ test_that("tagQuery()$parents() && tagQuery()$closest()", {
   x <- x$resetSelected()$find("span")$parents(".outer")
   expect_length(x$selectedTags(), 1)
 
-  expect_equal(
+  expect_equal_tags(
     x$selectedTags(),
     tagListPrintAsList(xTags)
   )
@@ -337,7 +337,7 @@ test_that("tagQuery()$addClass()", {
   x <- x$find("div.inner")$addClass("test-class")
   expect_length(x$selectedTags(), 1)
 
-  expect_equal(x$selectedTags()[[1]]$attribs$class, "inner test-class")
+  expect_equal_tags(x$selectedTags()[[1]]$attribs$class, "inner test-class")
 
   expect_silent({
     x$addClass(NULL)
@@ -428,7 +428,7 @@ test_that("tagQuery()$append()", {
 
   newa <- span("a")
   x$append(newa)
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div(span("child"), newa)
   )
@@ -437,7 +437,7 @@ test_that("tagQuery()$append()", {
   new2 <- div("new2")
   x$append(new1, new2)
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div(span("child"), newa, new1, new2)
   )
@@ -449,7 +449,7 @@ test_that("tagQuery()$prepend()", {
 
   newa <- span("a")
   x$prepend(newa)
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div(newa, span("child"))
   )
@@ -458,7 +458,7 @@ test_that("tagQuery()$prepend()", {
   new2 <- div("new2")
   x$prepend(new1, new2)
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div(new1, new2, newa, span("child"))
   )
@@ -479,7 +479,7 @@ test_that("tagQuery()$each()", {
     "ignored"
   })
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div(span("A"), h1("title"), span("B"))
   )
@@ -504,7 +504,7 @@ test_that("tagQuery()$allTags() & tagQuery()$rebuild()", {
   # make sure the last child is a tag env (not a standard tag)
   expect_false(isTagEnv(lastChild))
   # make sure it equals what was manually added
-  expect_equal(lastChild, div("test"))
+  expect_equal_tags(lastChild, div("test"))
 })
 
 
@@ -523,7 +523,7 @@ test_that("tagQuery()$remove()", {
   x <- x$filter(".A")$remove()
   expect_length(x$selectedTags(), 0)
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div(span("a"), span("c"), span("e"))
   )
@@ -531,7 +531,7 @@ test_that("tagQuery()$remove()", {
   x <- x$resetSelected()$find("span")
   expect_length(x$selectedTags(), 3)
   x <- x$remove()
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     div()
   )
@@ -544,7 +544,7 @@ test_that("tagQuery()$after()", {
 
   newa <- span("a")
   x$after(newa)
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     tagList(xTags, newa)
   )
@@ -553,7 +553,7 @@ test_that("tagQuery()$after()", {
   new2 <- div("new2")
   x$after(new1, new2)
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     tagList(xTags, new1, new2, newa)
   )
@@ -565,7 +565,7 @@ test_that("tagQuery()$before()", {
 
   newa <- span("a")
   x$before(newa)
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     tagList(newa, xTags)
   )
@@ -574,7 +574,7 @@ test_that("tagQuery()$before()", {
   new2 <- div("new2")
   x$before(new1, new2)
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     tagList(newa, new1, new2, xTags)
   )
@@ -592,7 +592,7 @@ test_that("tagQuery(x)$allTags()", {
 
   x <- tagQuery(xTags)
 
-  expect_equal(
+  expect_equal_tags(
     x$allTags(),
     tagList(!!!xTags)
   )
@@ -617,15 +617,15 @@ test_that("tagQuery() objects inherit from each other objects", {
 
   expected <- div(span(class="extra", "text"))
 
-  expect_equal(x$selectedTags(), tagListPrintAsList(!!!expected$children))
-  expect_equal(y$selectedTags(), tagListPrintAsList(!!!expected$children))
-  expect_equal(z$selectedTags(), tagListPrintAsList(!!!expected$children))
-  expect_equal(w$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal_tags(x$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal_tags(y$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal_tags(z$selectedTags(), tagListPrintAsList(!!!expected$children))
+  expect_equal_tags(w$selectedTags(), tagListPrintAsList(!!!expected$children))
 
-  expect_equal(x$allTags(), expected)
-  expect_equal(y$allTags(), expected)
-  expect_equal(z$allTags(), expected)
-  expect_equal(w$allTags(), expected)
+  expect_equal_tags(x$allTags(), expected)
+  expect_equal_tags(y$allTags(), expected)
+  expect_equal_tags(z$allTags(), expected)
+  expect_equal_tags(w$allTags(), expected)
 })
 
 
@@ -666,17 +666,17 @@ test_that("tagQuery() objects can not inherit from mixed objects", {
 test_that("rebuilding tag envs after inserting children is done", {
   xTags <- div(div(), div())
 
-  expect_equal(
+  expect_equal_tags(
     tagQuery(xTags)$find("div")$before(span())$allTags(),
     div(span(), div(), span(), div())
   )
 
-  expect_equal(
+  expect_equal_tags(
     tagQuery(xTags)$find("div")$replaceWith(span())$allTags(),
     div(span(), span())
   )
 
-  expect_equal(
+  expect_equal_tags(
     tagQuery(xTags)$find("div")$after(span())$allTags(),
     div(div(), span(), div(), span())
   )

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -65,7 +65,7 @@ test_that("asTagEnv upgrades objects", {
 #   xTagEnv$children[[3]] <- testSpanEnv
 
 #   expect_error(asTagEnv(xTagEnv), "Duplicate tag environment found")
-#   expect_equal(
+#   expect_equal_tags(
 #     tagEnvToTags(xTagEnv),
 #     div(
 #       class = "test_class",
@@ -266,13 +266,13 @@ test_that("tagQuery()$parents() && tagQuery()$closest()", {
   xc <- x$find("span")$closest()
   expect_length(xc$selectedTags(), 5)
   xc$each(function(el, i) {
-    expect_equal_tags(el$name, "span")
+    expect_equal(el$name, "span")
   })
 
   xp <- x$find("span")$parents("div")
   expect_length(xp$selectedTags(), 2)
-  expect_equal_tags(xp$hasClass("outer"), c(FALSE, TRUE))
-  expect_equal_tags(xp$hasClass("inner"), c(TRUE, FALSE))
+  expect_equal(xp$hasClass("outer"), c(FALSE, TRUE))
+  expect_equal(xp$hasClass("inner"), c(TRUE, FALSE))
 
   x <- x$find("span")$parents()
   expect_length(x$selectedTags(), 3)
@@ -337,7 +337,7 @@ test_that("tagQuery()$addClass()", {
   x <- x$find("div.inner")$addClass("test-class")
   expect_length(x$selectedTags(), 1)
 
-  expect_equal_tags(x$selectedTags()[[1]]$attribs$class, "inner test-class")
+  expect_equal(x$selectedTags()[[1]]$attribs$class, "inner test-class")
 
   expect_silent({
     x$addClass(NULL)

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -24,9 +24,6 @@ test_that("safeListToEnv and safeEnvToList undo each other", {
   expect_s3_class(xEnv, "extra_class")
 
   expect_equal(names(xEnv), c("A", "B"))
-  expect_equal(safeAttrValues(xEnv), list(extra_dep = list(42), other_dep = "exists"))
-
-  expect_equal(safeEnvToList(xEnv, "extra_class"), xExpected)
 })
 
 


### PR DESCRIPTION
(Similar to) before:
![Screen Shot 2021-05-13 at 12 02 37 PM](https://user-images.githubusercontent.com/93231/118152864-300c6980-b3e3-11eb-9f09-87cc64a924c2.png)

Now:
![Screen Shot 2021-05-13 at 12 01 56 PM](https://user-images.githubusercontent.com/93231/118152862-300c6980-b3e3-11eb-844c-5fc668b8993e.png)


* `mget()` is **MUCH** faster than `as.list.environment()` and shuffling the elements.
* Also removed usage of `setdiff()` if favor of wrapper to `x[match(x, y, 0L) == 0L]` to avoid a call to `unique()`
* Adjusted some `lapply` calls to `for-loop`s to avoid lapply overhead
* Adjusted some `walk` calls to `for-loops` to avoid usage of `<<-`