### PR TITLE
`tagQuery()`: Do not adjust the class attrib position when adding a class

### DIFF
--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1182,7 +1182,7 @@ tagEnvSetClassAttrib <- function(el, classes) {
   } else {
     # isClassLen > 0
     if (isClassLen > 1) {
-      # Remove other occurances of class
+      # Remove other occurrences of class
       el$attribs[classAttribPos[-1]] <- NULL
     }
     # Overwrite "class" attrib

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1178,17 +1178,19 @@ tagEnvSetClassAttrib <- function(el, classes) {
 
   if (isClassLen == 0) {
     # Store new class value
-    tagAppendAttributes(el, class = class)
-  } else {
-    # isClassLen > 0
-    if (isClassLen > 1) {
-      # Remove other occurrences of class
-      el$attribs[classAttribPos[-1]] <- NULL
-    }
-    # Overwrite "class" attrib
-    el$attribs[[classAttribPos[1]]] <- class
-    el
+    return(
+      tagAppendAttributes(el, class = class)
+    )
   }
+
+  # isClassLen > 0
+  if (isClassLen > 1) {
+    # Remove other occurrences of class
+    el$attribs[classAttribPos[-1]] <- NULL
+  }
+  # Overwrite "class" attrib
+  el$attribs[[classAttribPos[1]]] <- class
+  el
 }
 # add classes that don't already exist
 tagQueryClassAdd <- function(els, class) {

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1172,10 +1172,23 @@ isNonConformClassValue <- function(classVal) {
 }
 tagEnvSetClassAttrib <- function(el, classes) {
   class <- joinCssClass(classes)
-  # Remove all class instances as a single collective class value is being stored
-  el <- tagEnvRemoveAttribs(el, "class")
-  # Store new class value
-  tagAppendAttributes(el, class = class)
+
+  classAttribPos <- which(names(el$attribs) == "class")
+  isClassLen <- length(classAttribPos)
+
+  if (isClassLen == 0) {
+    # Store new class value
+    tagAppendAttributes(el, class = class)
+  } else {
+    # isClassLen > 0
+    if (isClassLen > 1) {
+      # Remove other occurances of class
+      el$attribs[classAttribPos[-1]] <- NULL
+    }
+    # Overwrite "class" attrib
+    el$attribs[[classAttribPos[1]]] <- class
+    el
+  }
 }
 # add classes that don't already exist
 tagQueryClassAdd <- function(els, class) {

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -835,7 +835,7 @@ test_that("adding a class does not reorder attribs", {
     div(class="bar foo", test = "A", "text")
   )
 
-  # Multiple classes class
+  # Multiple classes
   expect_equal_tags(
     tagQuery(div(class = "bar", test = "A", class = "baz", "text"))$addClass("foo")$allTags(),
     div(class = "bar baz foo", test = "A", "text")

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -821,7 +821,26 @@ test_that("tag methods do not unexpectedly alter tag envs", {
 })
 
 
+test_that("adding a class does not reorder attribs", {
 
+  # No class
+  expect_equal_tags(
+    tagQuery(div(test = "A", "text"))$addClass("foo")$allTags(),
+    div(test = "A", class = "foo", "text")
+  )
+
+  # One class
+  expect_equal_tags(
+    tagQuery(div(class = "bar", test = "A", "text"))$addClass("foo")$allTags(),
+    div(class="bar foo", test = "A", "text")
+  )
+
+  # Multiple classes class
+  expect_equal_tags(
+    tagQuery(div(class = "bar", test = "A", class = "baz", "text"))$addClass("foo")$allTags(),
+    div(class = "bar baz foo", test = "A", "text")
+  )
+})
 
 
 


### PR DESCRIPTION
Previous approach: Remove all `class` values, Add the new `class` value.

New approach: 
* If no `class` values
	* Add the new `class` value
* Else
	* If more than one `class` values
		* Remove the extra occurrences of `class`
	* Overwrite the first `class` value


With the new approach, the first class position is kept, preserving the attribute order