### PR TITLE
Specify which version of fastmap to use

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     grDevices,
     base64enc,
     rlang (>= 0.4.10),
-    fastmap
+    fastmap (>= 1.1.0)
 Suggests:
     markdown,
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # htmltools 0.5.2.9000
 
+## Bug fixes
+
+* Closed #290: htmltools previously did not specify which version of fastmap to use, and would fail to install with an old version of fastmap. (#291)
+
 # htmltools 0.5.2
 
 ## Breaking Changes


### PR DESCRIPTION
Closes #290. Older versions of fastmap did not include `faststack()`; this PR specifies the minimum version of fastmap to use.