### PR TITLE
`tagQuery()`: Relocate html deps to child objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-* Closed #301: `tagQuery()` was failing to copy all `tagList()` html dependencies within nest child tag lists. (#302)
+* Closed #301: `tagQuery()` was failing to copy all `tagList()` html dependencies within nest child tag lists. `tagQuery()` will now relocate html dependencies as child objects. (#302)
 
 * Closed #290: htmltools previously did not specify which version of fastmap to use, and would fail to install with an old version of fastmap. (#291)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+* Closed #301: `tagQuery()` was failing to copy all `tagList()` html dependencies within nest child tag lists. (#302)
+
 * Closed #290: htmltools previously did not specify which version of fastmap to use, and would fail to install with an old version of fastmap. (#291)
 
 * `copyDependencyToDir()` no longer creates empty directories for dependencies that do not have any files. (@gadenbuie, #276)

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -427,13 +427,27 @@ tagQueryAsTagErr <- function() {
 #' [`jQuery`](https://jquery.com/) inspired interface for querying and modifying
 #' [tag()] (and [tagList()]) objects.
 #'
+#' @section Altered Tag structure:
+#'
+#' For performance reasons, the input tag structure to `tagQuery()` will be
+#' altered into a consistently expected shape.
+#'
+#' Some alterations include:
+#' * tags flattening their `$children` fields into a single `list()`
+#' * tags relocating any attribute `html_dependency() to be located in `$children`
+#' * `tagList()`-like structures relocating any attribute html dependency to
+#'   be a entry in its list structure.
+#'
+#' While the resulting tag shape has possibly changed,
+#' `tagQuery()`'s' resulting tags will still render
+#' to the same HTML value (ex: [`renderTags()`]) and
+#' HTML dependencies (ex: [`findDependencies()`]).
+#'
 #' @param tags A [tag()], [tagList()], or [list()] of tags.
 #' @return A class with methods that are described below. This class can't be
 #'   used directly inside other [tag()] or a [renderTags()] context, but
 #'   underlying HTML tags may be extracted via `$allTags()` or
-#'   `$selectedTags()`. Note: The returned tags will have their `$children`
-#'   fields flattened to a single `list()`, which may not be the same shape
-#'   that was provided to `tagQuery()`.
+#'   `$selectedTags()`.
 #' @export
 tagQuery <- function(tags) {
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -1292,6 +1292,14 @@ flattenTagsRaw <- function(x) {
       ret <- unlist(lapply(x, flattenTagsRaw), recursive = FALSE)
       # Copy over attributes put on the original list (ex: html deps)
       mostattributes(ret) <- attributes(x)
+
+      # Copy over individual html deps into the final list
+      # This does not work for attributes in general,
+      # but we can make it work for html deps
+      x_html_deps <- unlist(lapply(x, htmlDependencies), recursive = FALSE)
+      if (length(x_html_deps) > 0) {
+        ret <- attachDependencies(ret, x_html_deps, append = TRUE)
+      }
       ret
     }
   } else {

--- a/R/tags.R
+++ b/R/tags.R
@@ -1289,14 +1289,15 @@ flattenTagsRaw <- function(x) {
       x
     } else {
       # For items that are lists (but not tags), recurse
-      ret <- unlist(lapply(x, flattenTagsRaw), recursive = FALSE)
+      flattened_tags <- lapply(x, flattenTagsRaw)
+      ret <- unlist(flattened_tags, recursive = FALSE)
       # Copy over attributes put on the original list (ex: html deps)
       mostattributes(ret) <- attributes(x)
 
-      # Copy over individual html deps into the final list
+      # Copy over individual html deps into the final list from the flattened tags
       # This does not work for attributes in general,
       # but we can make it work for html deps
-      x_html_deps <- unlist(lapply(x, htmlDependencies), recursive = FALSE)
+      x_html_deps <- unlist(lapply(flattened_tags, htmlDependencies), recursive = FALSE)
       if (length(x_html_deps) > 0) {
         ret <- attachDependencies(ret, x_html_deps, append = TRUE)
       }

--- a/R/tags.R
+++ b/R/tags.R
@@ -1280,37 +1280,56 @@ flattenTags <- function(x) {
 # By not calling `as.tags(x)`, tagFunctions are not evaluated and other items
 # are not converted.
 flattenTagsRaw <- function(x) {
+  relocateHtmlDeps <- function(z, type) {
+    zDeps <- htmlDependencies(z)
+    zDepsLen <- length(zDeps)
+    # Return early if there are no dependencies
+    if (zDepsLen == 0) return(z)
+
+    # Append the incoming html deps to z's children
+    # Perform position insert to not lose attrs on z/z$children
+    switch(type,
+      "tag" = {
+        children <- z[["children"]]
+        childrenLen <- length(children)
+        if (is.null(children)) {
+          z[["children"]] <- zDeps
+        } else {
+          z[["children"]][(childrenLen + 1):(childrenLen + zDepsLen)] <- zDeps
+        }
+      },
+      "tagList" = {
+        zLen <- length(z)
+        z[(zLen + 1):(zLen + zDepsLen)] <- zDeps
+      },
+      stop("unknown type: ", type)
+    )
+    # Remove html deps on z, as they are now in the children
+    htmlDependencies(z) <- NULL
+
+    z
+  }
+
   if (isTagEnv(x)) {
     # For tags, wrap them into a list (which will be unwrapped by caller)
     list(x)
   } else if (isTag(x)) {
-    tagDeps <- htmlDependencies(x)
-    # Move the tag's html deps to its children
-    if (length(tagDeps) > 0) {
-      x$children <- c(x$children, tagDeps)
-      htmlDependencies(x) <- NULL
-    }
+    # Append individual html deps as children elements.
+    # Attributes are eaisly lost when unlisted or collected.
+    # Instead, use the _newer_/stable approach of adding the html dep as a direct child
+    x <- relocateHtmlDeps(x, type = "tag")
     # For tags, wrap them into a list (which will be unwrapped by caller)
     list(x)
   } else if (isTagList(x)) {
     # For items that are lists (but not tags), recurse
     ret <- unlist(lapply(x, flattenTagsRaw), recursive = FALSE)
-    # Copy over attributes put on the original list (ex: html deps)
+    # Copy over attributes put on the original list (ex: html deps, class)
     mostattributes(ret) <- attributes(x)
-
     # Append individual html deps into the final list from the flattened tags
     # It does not work out well to add attributes to `ret`, as the html deps are not found by findDependencies()
     # Instead, use the _newer_/stable approach of adding the html dep as a direct child
-    tagListDeps <- htmlDependencies(ret)
-    # Append the incoming tagList's html deps to its children
-    tagListDepsLen <- length(tagListDeps)
-    if (tagListDepsLen > 0) {
-      # Do position insert to not lose attrs on ret
-      retLen <- length(ret)
-      ret[(retLen + 1):(retLen + tagListDepsLen)] <- tagListDeps
-      # Remove html deps on ret, as they are now in the children
-      htmlDependencies(ret) <- NULL
-    }
+    ret <- relocateHtmlDeps(ret, type = "tagList")
+    # Return the list of items
     ret
   } else {
     # This will preserve attributes if x is a character with attribute,
@@ -1318,6 +1337,7 @@ flattenTagsRaw <- function(x) {
     list(x)
   }
 }
+
 
 
 combineKeys <- function(x) {

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -13,15 +13,33 @@ tagQuery(tags)
 A class with methods that are described below. This class can't be
 used directly inside other \code{\link[=tag]{tag()}} or a \code{\link[=renderTags]{renderTags()}} context, but
 underlying HTML tags may be extracted via \verb{$allTags()} or
-\verb{$selectedTags()}. Note: The returned tags will have their \verb{$children}
-fields flattened to a single \code{list()}, which may not be the same shape
-that was provided to \code{tagQuery()}.
+\verb{$selectedTags()}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}\cr\cr \code{tagQuery()} provides a
 \href{https://jquery.com/}{\code{jQuery}} inspired interface for querying and modifying
 \code{\link[=tag]{tag()}} (and \code{\link[=tagList]{tagList()}}) objects.
 }
+\section{Altered Tag structure}{
+
+
+For performance reasons, the input tag structure to \code{tagQuery()} will be
+altered into a consistently expected shape.
+
+Some alterations include:
+\itemize{
+\item tags flattening their \verb{$children} fields into a single \code{list()}
+\item tags relocating any attribute \verb{html_dependency() to be located in }$children`
+\item \code{tagList()}-like structures relocating any attribute html dependency to
+be a entry in its list structure.
+}
+
+While the resulting tag shape has possibly changed,
+\code{tagQuery()}'s' resulting tags will still render
+to the same HTML value (ex: \code{\link[=renderTags]{renderTags()}}) and
+HTML dependencies (ex: \code{\link[=findDependencies]{findDependencies()}}).
+}
+
 \section{Vignette}{
 To get started with using \code{tagQuery()}, visit
 \url{https://rstudio.github.io/htmltools/articles/tagQuery.html}.

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -842,6 +842,30 @@ test_that("adding a class does not reorder attribs", {
   )
 })
 
+test_that("tag list html deps are not lost when tag children are squashed", {
+  # https://github.com/rstudio/htmltools/issues/301
+
+  a_dep <- htmlDependency(name = "A", version = 1, src = "a.js")
+  b_dep <- htmlDependency(name = "B", version = 2, src = "b.js")
+  c_dep <- htmlDependency(name = "C", version = 3, src = "c.js")
+
+  children <-
+    attachDependencies(
+      list(
+        attachDependencies(list("X", "Y"), a_dep),
+        "Z"
+      ),
+      list(b_dep, c_dep)
+    )
+
+  html <- div("test", children)
+  tq_html <- tagQuery(html)$allTags()
+
+  tq_deps <- findDependencies(tq_html$children)
+  expect_length(tq_deps, 3)
+  expect_equal(tq_deps, list(b_dep, c_dep, a_dep))
+})
+
 
 
 


### PR DESCRIPTION
Fixes #301 
cc @DavidJesse21

- [x] test added
- [x] news entry
- [x] document that tag query will relocate all htmldeps after usage (and also flatten nested lists in children)