### PR TITLE
Another attempt at fixing issues with pandoc's raw attribute usage in htmlPreserve()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # htmltools 0.5.2.9000
 
+## Breaking changes
+
+* Closed #305: `htmlPreserve()` no longer uses _inline_ code blocks for Pandoc's raw attribute feature when used inside a _non_-inline knitr/rmarkdown code chunk, and as a result, in this case, an additional `<p>` tag is no longer wrapped around the HTML content. (#306)
+
 ## Bug fixes
 
 * Closed #301: `tagQuery()` was failing to copy all `tagList()` html dependencies within nest child tag lists. `tagQuery()` will now relocate html dependencies as child objects. (#302)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,5 @@
 # htmltools 0.5.2.9000
 
-## Breaking changes
-
-* Closed #305: `htmlPreserve()` no longer uses inline code blocks for Pandoc's raw attribute feature (i.e., when `options(htmltools.preserve.raw = TRUE)`. As a result, rmarkdown no longer adds an addition `<p>` tag around 'literal' HTML. (#306)
-
 ## Bug fixes
 
 * Closed #301: `tagQuery()` was failing to copy all `tagList()` html dependencies within nest child tag lists. `tagQuery()` will now relocate html dependencies as child objects. (#302)

--- a/R/tags.R
+++ b/R/tags.R
@@ -1497,9 +1497,7 @@ html_preserve <- function(x, inline = "auto") {
   # that come with preserving HTML via pandoc 2.0's raw attribute feature
   # https://github.com/rstudio/rmarkdown/pull/1965#issuecomment-734804176
   if (!getOption("htmltools.preserve.raw", FALSE)) {
-    return(
-      sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x)
-    )
+    return(sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x))
   }
 
   # With no other context, the presence of line break(s) is used

--- a/R/tags.R
+++ b/R/tags.R
@@ -1482,7 +1482,7 @@ as.tags.html_dependency <- function(x, ...) {
 #'
 #' @export
 htmlPreserve <- function(x) {
-  html_preserve(x)
+  html_preserve(x, inline = "auto")
 }
 
 html_preserve <- function(x, inline = "auto") {

--- a/R/tags.R
+++ b/R/tags.R
@@ -1482,22 +1482,22 @@ as.tags.html_dependency <- function(x, ...) {
 #'
 #' @export
 htmlPreserve <- function(x) {
+  raw = getOption("htmltools.preserve.raw", FALSE)
   x <- paste(x, collapse = "\n")
-  # Do nothing for empty string
-  if (!nzchar(x)) {
-    return(x)
-  }
-  # rmarkdown sets this option to TRUE to leverage various benefits
-  # that come with preserving HTML via pandoc 2.0's raw attribute feature
-  # https://github.com/rstudio/rmarkdown/pull/1965#issuecomment-734804176
-  if (!getOption("htmltools.preserve.raw", FALSE)) {
-    return(sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x))
-  }
-  # Always use the block (not inline) form since the latter wraps x in
-  # a <p> tag, which can have unfortunate consequences, most notably
-  # https://github.com/rstudio/flexdashboard/issues/379
-  # https://github.com/rstudio/rmarkdown/issues/2259#issuecomment-995996958
-  sprintf("\n```{=html}\n%s\n```\n", x)
+  if (nzchar(x))
+    if (raw) {
+      # use fenced code block if there are embedded newlines
+      if (grepl("\n", x, fixed = TRUE))
+        sprintf("\n```{=html}\n%s\n```\n", x)
+      # otherwise use inline span
+      else
+        sprintf("`%s`{=html}", x)
+    }
+    else {
+      sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x)
+    }
+  else
+    x
 }
 
 # Temporarily set x in env to value, evaluate expr, and

--- a/R/tags.R
+++ b/R/tags.R
@@ -1500,17 +1500,14 @@ html_preserve <- function(x, inline = "auto") {
     return(sprintf("<!--html_preserve-->%s<!--/html_preserve-->", x))
   }
 
-  # With no other context, the presence of line break(s) is used
-  # to determine whether a block or inline code chunk should be
-  # used for pandoc's raw attributes. This is problematic, however, when
-  # embedding shiny apps in flexdashboard (for example) since the inline form
-  # adds an additional <p> tag around the HTML (iframe in that case, which can
-  # mess up the computed height since the parent-child relationship is changed)
-  # https://github.com/rstudio/flexdashboard/issues/379
-  # https://github.com/rstudio/rmarkdown/issues/2259#issuecomment-995996958
-  #
+  # With no other context, the presence of line break(s) determines whether a
+  # block or inline code chunk is used for pandoc's raw attributes (the inline
+  # version may add an additional <p> tag around the HTML (which can be
+  # problematic, for instance, when embedding shiny inside flexdashboard)
   # Thankfully knitr::knit_print() can tell us whether we're inside a inline
   # code which is why this is here essentially just for non-knit usage
+  # https://github.com/rstudio/flexdashboard/issues/379
+  # https://github.com/rstudio/rmarkdown/issues/2259#issuecomment-995996958
   if (identical(inline, "auto")) {
     inline <- grepl(x, "\n", fixed = TRUE)
   }
@@ -1686,6 +1683,7 @@ restorePreserveChunks <- function(strval, chunks) {
 #' @name knitr_methods
 #' @param x Object to knit_print
 #' @param ... Additional knit_print arguments
+#' @param inline Whether or not the code chunk is inline.
 NULL
 
 #' @rdname knitr_methods

--- a/man/knitr_methods.Rd
+++ b/man/knitr_methods.Rd
@@ -17,6 +17,8 @@ knit_print.shiny.tag.list(x, ..., inline = FALSE)
 \item{x}{Object to knit_print}
 
 \item{...}{Additional knit_print arguments}
+
+\item{inline}{Whether or not the code chunk is inline.}
 }
 \description{
 These S3 methods are necessary to allow HTML tags to print themselves in

--- a/man/knitr_methods.Rd
+++ b/man/knitr_methods.Rd
@@ -7,11 +7,11 @@
 \alias{knit_print.shiny.tag.list}
 \title{Knitr S3 methods}
 \usage{
-knit_print.shiny.tag(x, ...)
+knit_print.shiny.tag(x, ..., inline = FALSE)
 
-knit_print.html(x, ...)
+knit_print.html(x, ..., inline = FALSE)
 
-knit_print.shiny.tag.list(x, ...)
+knit_print.shiny.tag.list(x, ..., inline = FALSE)
 }
 \arguments{
 \item{x}{Object to knit_print}


### PR DESCRIPTION
Closes https://github.com/rstudio/htmltools/issues/307 (i.e., this should be a better way of fixing https://github.com/rstudio/htmltools/issues/305 than #306 was)