### PR TITLE
fix: copyDependencyToDir tries to copy non-existent files unintentionally

### DIFF
--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -355,7 +355,10 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
   dependency$src$file <- normalizePath(target_dir, "/", TRUE)
 
   files <- if (dependency$all_files) list.files(dir) else {
-    unlist(dependency[c('script', 'stylesheet', 'attachment')])
+    c(
+      src_script(dependency[["script"]]),
+      unlist(dependency[c('stylesheet', 'attachment')])
+    )
   }
 
   if (length(files) == 0) {
@@ -387,6 +390,23 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
   }, srcfiles, destfiles, isdir)
 
   dependency
+}
+
+src_script <- function(script, allow_unnamed_list = TRUE) {
+  if (is.null(script) || is.character(script)) return(script)
+  if (!is.list(script)) stop(
+    "Script must be specified as a character vector, a named list, ",
+    "or a unnamed list combining the former two. ",
+    "See `?htmltools::htmlDependency` for the detail."
+  )
+
+  if (rlang::is_named(script)) return(script[["src"]])
+  if (!allow_unnamed_list) stop(
+    "When script is specified by an unnamed list, its elements must be ",
+    "character vectors or named lists.",
+    "See `?htmltools::htmlDependency` for the detail."
+  )
+  unlist(lapply(script, src_script, allow_unnamed_list = FALSE))
 }
 
 dir_exists <- function(paths) {

--- a/tests/testthat/test-deps.r
+++ b/tests/testthat/test-deps.r
@@ -357,3 +357,31 @@ test_that("copyDependencyToDir() doesn't create an empty directory", {
   # to keep relativeTo() from throwing an error later in Rmd render process
   expect_match(copied_dep$src$file, normalizePath(tmp_rmd, "/", TRUE), fixed = TRUE)
 })
+
+test_that("copyDependencyToDir() supports script as character or list", {
+  # Prepare example data
+  src <- tempfile()
+  dir.create(src, showWarnings = FALSE)
+  script <- c("1.js", "2.js")
+  invisible(file.create(file.path(src, script)))
+  copy_dep <- function(...) {
+    outputDir = tempfile()
+    dir.create(outputDir, showWarnings = FALSE)
+    copyDependencyToDir(
+      htmlDependency(name = "example", version = "1.0", src = src, ...),
+      outputDir = outputDir
+    )
+    all(file.exists(file.path(outputDir, src_script(script))))
+  }
+  for (all_files in c(TRUE, FALSE)) {
+    expect_true(copy_dep(script = script, all_files = TRUE))
+    expect_true(copy_dep(script = list(src = script), all_files = all_files))
+    expect_true(copy_dep(
+      script = list(
+        script[1L],
+        list(src = script[2L], defer = NA)
+      ),
+      all_files = all_files
+    ))
+  }
+})

--- a/tests/testthat/test-deps.r
+++ b/tests/testthat/test-deps.r
@@ -371,10 +371,10 @@ test_that("copyDependencyToDir() supports script as character or list", {
       htmlDependency(name = "example", version = "1.0", src = src, ...),
       outputDir = outputDir
     )
-    all(file.exists(file.path(outputDir, src_script(script))))
+    all(file.exists(file.path(outputDir, "example-1.0", script)))
   }
   for (all_files in c(TRUE, FALSE)) {
-    expect_true(copy_dep(script = script, all_files = TRUE))
+    expect_true(copy_dep(script = script, all_files = all_files))
     expect_true(copy_dep(script = list(src = script), all_files = all_files))
     expect_true(copy_dep(
       script = list(


### PR DESCRIPTION
when script is a list and `all_files` is `FALSE`

This happens because `copyDependencyToDir` considers `unlist(dependency[c('script', 'stylesheet', 'attachment')])` as paths to files, but script can be a list with some html attributes such as `defer`.

``` r
library(htmltools)

# Prepare example data
src <- tempfile()
dir.create(src, showWarnings = FALSE)
script <- c("1.js", "2.js")
invisible(file.create(file.path(src, script)))
deps <- htmlDependency(
  name = "example",
  version = "1.0",
  src = src,
  #script = script,
  script = lapply(script, function(x) list(src = x, defer = NA)),
  all_files = FALSE
)

# Try copyDependencyToDir
outputDir = tempfile()
dir.create(outputDir, showWarnings = FALSE)
copyDependencyToDir(deps,outputDir = outputDir)
#> Error in htmltools::copyDependencyToDir(deps, outputDir = outputDir): Can't copy dependency files that don't exist: '/tmp/RtmpzXKs5M/file121c6ec550eb/1.js', '/tmp/RtmpzXKs5M/file121c6ec550eb/NA', '/tmp/RtmpzXKs5M/file121c6ec550eb/2.js', '/tmp/RtmpzXKs5M/file121c6ec550eb/NA'
```

<sup>Created on 2021-12-29 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>

