### PR TITLE
Update CLA links and alias

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@ We welcome contributions to the **htmltools** package. To submit a contribution:
 
 1. [Fork](https://github.com/rstudio/htmltools/fork) the repository and make your changes.
 
-2. Ensure that you have signed the [individual](https://www.rstudio.com/wp-content/uploads/2014/06/rstudioindividualcontributoragreement.pdf) or [corporate](https://www.rstudio.com/wp-content/uploads/2014/06/rstudiocorporatecontributoragreement.pdf) contributor agreement as appropriate. You can send the signed copy to contribute@rstudio.com.
+2. Submit a [pull request](https://help.github.com/articles/using-pull-requests).
 
-3. Submit a [pull request](https://help.github.com/articles/using-pull-requests).
+3. You will be prompted to read and agree to the "RStudio Corporate and Individual Contributor Agreement."
 
 We generally do not merge pull requests that update included web libraries (such as Bootstrap or jQuery) because it is difficult for us to verify that the update is done correctly; we prefer to update these libraries ourselves.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ We welcome contributions to the **htmltools** package. To submit a contribution:
 
 1. [Fork](https://github.com/rstudio/htmltools/fork) the repository and make your changes.
 
-2. Ensure that you have signed the [individual](https://rstudioblog.files.wordpress.com/2017/05/rstudio_individual_contributor_agreement.pdf) or [corporate](https://rstudioblog.files.wordpress.com/2017/05/rstudio_corporate_contributor_agreement.pdf) contributor agreement as appropriate. You can send the signed copy to jj@rstudio.com.
+2. Ensure that you have signed the [individual](https://www.rstudio.com/wp-content/uploads/2014/06/rstudioindividualcontributoragreement.pdf) or [corporate](https://www.rstudio.com/wp-content/uploads/2014/06/rstudiocorporatecontributoragreement.pdf) contributor agreement as appropriate. You can send the signed copy to contribute@rstudio.com.
 
 3. Submit a [pull request](https://help.github.com/articles/using-pull-requests).
 


### PR DESCRIPTION
Updating to point to the current CLA PDFs on rstudio.com, and to change email address people should send them to.

More on this at: https://github.com/rstudio/rstudio/issues/10609