### PR TITLE
Create dependency output directory recursively when copying

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # htmltools 0.5.3.9000
 
+## Bug fixes
+
+* Closed #331: `copyDependencyToDir()` creates `outputDir` recursively, which happens in Quarto or when `lib_dir` points to a nested directory. (@gadenbuie, #332)
 
 
 # htmltools 0.5.3

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -336,7 +336,7 @@ copyDependencyToDir <- function(dependency, outputDir, mustWork = TRUE) {
     stop('outputDir must be of length 1 and cannot be "" or "/"')
 
   if (!dir_exists(outputDir))
-    dir.create(outputDir)
+    dir.create(outputDir, recursive = TRUE)
 
   target_dir <- if (getOption('htmltools.dir.version', TRUE)) {
     paste(dependency$name, dependency$version, sep = "-")

--- a/tests/testthat/test-deps.r
+++ b/tests/testthat/test-deps.r
@@ -358,6 +358,36 @@ test_that("copyDependencyToDir() doesn't create an empty directory", {
   expect_match(copied_dep$src$file, normalizePath(tmp_rmd, "/", TRUE), fixed = TRUE)
 })
 
+test_that("copyDependencyToDir() creates recursive output directories", {
+  tmp_dep <- tempfile("dep")
+  dir.create(tmp_dep)
+  on.exit(unlink(tmp_dep, recursive = TRUE))
+
+  writeLines(
+    c("alert('boo')"),
+    file.path(tmp_dep, "script.js")
+  )
+
+  dep <- htmltools::htmlDependency(
+    name = "simple",
+    version = "9.9.9",
+    src = tmp_dep,
+    script = "script.js",
+    all_files = FALSE
+  )
+
+  tmp_outputDir <- file.path(tempfile("outputDir"), "subdir")
+  on.exit(unlink(tmp_outputDir, recursive = TRUE), add = TRUE)
+
+  expect_silent(copyDependencyToDir(dep, tmp_outputDir))
+
+  # copyDependencyToDir() creates the nested outputDir
+  expect_true(dir_exists(file.path(tmp_outputDir)))
+  # it moves the dependency into this dir
+  expect_true(dir_exists(file.path(tmp_outputDir, "simple-9.9.9")))
+  expect_true(file.exists(file.path(tmp_outputDir, "simple-9.9.9", "script.js")))
+})
+
 test_that("copyDependencyToDir() handles attributes", {
   tmp_dep <- tempfile("dep")
   dir.create(tmp_dep)


### PR DESCRIPTION
This PR fixes #331 by having `copyDependencyToDir()` create the `outputDir` recursively. Previously, this was a side effect of a later call to `file.copy()`, so this change makes the recursive directory creation explicit. It's also necessary when a nested directory is required because `normalizePath()` will fail otherwise.