### PR TITLE
Fix bug in `tagQuery()`'s `$remove()`, `$after()`, `$before()`, `$replaceWith()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.3.9001
+Version: 0.5.3.9002
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@rstudio.com"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@rstudio.com", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 
 * Closed #331: `copyDependencyToDir()` creates `outputDir` recursively, which happens in Quarto or when `lib_dir` points to a nested directory. (@gadenbuie, #332)
 
+* Closed #346: `tagQuery()`'s `$remove()`, `$after()`, `$before()`, `$replaceWith()` had a bug that prevented expected behavior when sibling children values where not tag elements. (#348)
+
+
 # htmltools 0.5.3
 
 ## Breaking changes
@@ -23,6 +26,7 @@
 * `copyDependencyToDir()` no longer creates empty directories for dependencies that do not have any files. (@gadenbuie, #276)
 
 * Closed #320: `copyDependencyToDir()` now works with dependencies with specified attributes. (@dmurdoch, #321)
+
 
 # htmltools 0.5.2
 

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1023,7 +1023,8 @@ tagQuerySiblingRemove <- function(els) {
   tagQueryMatchChildRev(els, function(elParent, el, childPos) {
     # remove parent / child relationship
     el$parent <- NULL
-    elParent$children[[childPos]] <- NULL
+    # Remove the child entry completely
+    elParent$children[childPos] <- NULL
   })
 }
 # Add siblings after each el

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1023,8 +1023,7 @@ tagQuerySiblingRemove <- function(els) {
   tagQueryMatchChildRev(els, function(elParent, el, childPos) {
     # remove parent / child relationship
     el$parent <- NULL
-    # Remove the child entry completely
-    elParent$children[childPos] <- NULL
+    elParent$children[[childPos]] <- NULL
   })
 }
 # Add siblings after each el

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1006,7 +1006,7 @@ tagQueryMatchChildRev <- function(els, func) {
     elParent <- el$parent
     # Walk in reverse to be able to remove all matches in a single pass
     selectedWalkIRev(elParent$children, function(child, childPos) {
-      if (!isTagEnv(el)) return()
+      if (!isTagEnv(child)) return()
       childKey <- child$envKey
       if (elKey == childKey) {
         func(elParent, el, childPos)

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -550,23 +550,11 @@ test_that("tagQuery()$remove()", {
   )
 
   # https://github.com/rstudio/htmltools/issues/346
-  skip_if_not_installed("shiny")
-  html <- shiny::selectInput("select_id", "label", letters)
+  # `isTagEnv("Barret")` is `FALSE`
+  html <- div(tags$label("Carson"), "Barret")
   # Remove the label
-  final_html <- tagQuery(html)$
-    find("label")$
-    remove()$
-    allTags()
-
-  html_ex <- shiny::selectInput("select_id", "label", letters)
-  # Remove label
-  label_pos <- which(vapply(html_ex$children, `[[`, character(1), "name") == "label")
-  expect_equal(length(label_pos), 1)
-  html_ex$children[label_pos] <- NULL
-  # Relocate html deps (due to `flattenTagsRaw()`)
-  html_expected <- tagQuery(html_ex)$allTags()
-
-  expect_equal_tags(final_html, html_expected)
+  x <- tagQuery(html)$find("label")$remove()
+  expect_equal_tags(x$allTags(), div("Barret"))
 })
 
 

--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -548,6 +548,25 @@ test_that("tagQuery()$remove()", {
     x$allTags(),
     div()
   )
+
+  # https://github.com/rstudio/htmltools/issues/346
+  skip_if_not_installed("shiny")
+  html <- shiny::selectInput("select_id", "label", letters)
+  # Remove the label
+  final_html <- tagQuery(html)$
+    find("label")$
+    remove()$
+    allTags()
+
+  html_ex <- shiny::selectInput("select_id", "label", letters)
+  # Remove label
+  label_pos <- which(vapply(html_ex$children, `[[`, character(1), "name") == "label")
+  expect_equal(length(label_pos), 1)
+  html_ex$children[label_pos] <- NULL
+  # Relocate html deps (due to `flattenTagsRaw()`)
+  html_expected <- tagQuery(html_ex)$allTags()
+
+  expect_equal_tags(final_html, html_expected)
 })
 
 


### PR DESCRIPTION
Fixes #346

`tagQuery()`'s `$remove()`, `$after()`, `$before()`, `$replaceWith()` had a bug that prevented expected behavior when sibling children values where not tag elements.

Other changes:
* ~~Removed elements are now **completely** removed from the `$children` attr. (Not just replaced with `NULL` which is processed like a no-op.)~~