### PR TITLE
Avoid testing messages generated in rlang

### DIFF
--- a/tests/testthat/_snaps/tags.md
+++ b/tests/testthat/_snaps/tags.md
@@ -1,3 +1,18 @@
+# Hanging commas don't break things
+
+    Code
+      (expect_error(as.character(div("one", , ))))
+    Output
+      <error/rlang_error>
+      Error in `dots_list()`:
+      ! Argument 2 can't be empty.
+    Code
+      (expect_error(as.character(div(, "one", ))))
+    Output
+      <error/rlang_error>
+      Error in `dots_list()`:
+      ! Argument 1 can't be empty.
+
 # html render method
 
     Code

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -25,10 +25,14 @@ test_that("Basic tag writing works", {
 test_that("Hanging commas don't break things", {
   expect_equal(as.character(tagList("hi",)), "hi")
   expect_equal(as.character(div("one",)), "<div>one</div>")
-  # Multiple commas still throw
-  expect_error(as.character(div("one",,)), "is empty")
-  # Non-trailing commas still throw
-  expect_error(as.character(div(,"one",)), "is empty")
+
+  local_edition(3)
+  expect_snapshot({
+    # Multiple commas still throw
+    (expect_error(as.character(div("one",,))))
+    # Non-trailing commas still throw
+    (expect_error(as.character(div(,"one",))))
+  })
 })
 
 


### PR DESCRIPTION
The error message in case of empty arguments has changed slightly in the next version of rlang that is about to be sent to CRAN. This causes some tests in htmltools to fail because they check the exact content of error messages generated in a third party package. To avoid this, I changed the expectations to error snapshots.