### PR TITLE
Update tests to accomodate new trailing comma error message from rlang

### DIFF
--- a/tests/testthat/_snaps/tags.md
+++ b/tests/testthat/_snaps/tags.md
@@ -1,3 +1,21 @@
+# Hanging commas don't break things
+
+    Code
+      err_comma_multiple
+    Output
+      <error/rlang_error>
+      Error in `dots_list()`:
+      ! Argument 2 can't be empty.
+
+---
+
+    Code
+      err_comma_leading
+    Output
+      <error/rlang_error>
+      Error in `dots_list()`:
+      ! Argument 1 can't be empty.
+
 # html render method
 
     Code

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -26,9 +26,16 @@ test_that("Hanging commas don't break things", {
   expect_equal(as.character(tagList("hi",)), "hi")
   expect_equal(as.character(div("one",)), "<div>one</div>")
   # Multiple commas still throw
-  expect_error(as.character(div("one",,)), "empty")
+  err_comma_multiple <- expect_error(as.character(div("one",,)))
   # Non-trailing commas still throw
-  expect_error(as.character(div(,"one",)), "empty")
+  err_comma_leading <- expect_error(as.character(div(,"one",)))
+
+  # rlang > 1.0.6 changed the error message, so only run
+  # snapshot testing of the error message with the new version
+  skip_if_not_installed("rlang", "1.0.6.9000")
+  local_edition(3)
+  expect_snapshot(err_comma_multiple)
+  expect_snapshot(err_comma_leading)
 })
 
 

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -26,9 +26,9 @@ test_that("Hanging commas don't break things", {
   expect_equal(as.character(tagList("hi",)), "hi")
   expect_equal(as.character(div("one",)), "<div>one</div>")
   # Multiple commas still throw
-  expect_error(as.character(div("one",,)), "is empty")
+  expect_error(as.character(div("one",,)), "empty")
   # Non-trailing commas still throw
-  expect_error(as.character(div(,"one",)), "is empty")
+  expect_error(as.character(div(,"one",)), "empty")
 })
 
 


### PR DESCRIPTION
Supersedes #367.

This change makes the tests pass with both the old rlang <1.0.7 error message:

```r
> rlang::list2(,1)
! Argument 1 is empty
```

As well as the new rlang >= 1.0.7

```r
> rlang::list2(,1)
! Argument 1 can't be empty.
```