### PR TITLE
Embed complete documents provided to `includeHTML()` in an iframe

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -1736,10 +1736,10 @@ knit_print.html_dependency <- knit_print.shiny.tag
 #' @param iframe_args If the HTML document at `path` is a complete HTML
 #'   document, the document is included within an `<iframe>`. In this case,
 #'   `iframe_args` may include a list of arguments to be passed to
-#'   `tags$iframe()`. The default arguments set `width`, `height`,
-#'   `frameBorder`, `seamless`, and `scrolling`. The values in `iframe_args`
-#'   will be merged with or will override these defaults. You can unset any of
-#'   the default values by setting them to `NULL` in `iframe_args`.
+#'   `tags$iframe()`. The default arguments set `width`, `height`, and
+#'   `frameborder`. The values in `iframe_args` will be merged with or will
+#'   override these defaults. You can unset any of the default values by setting
+#'   them to `NULL` in `iframe_args`, e.g. `list(frameborder = NULL)`.
 #'
 #' @rdname include
 #' @name include
@@ -1750,8 +1750,15 @@ includeHTML <- function(path, iframe_args = NULL) {
   lines <- paste0(lines, collapse='\n')
 
   if (detect_html_document(lines)) {
+    iframe_args_default <- list(
+      width = "100%",
+      height = "400px",
+      frameborder = "0"
+    )
+
     if (is.null(iframe_args)) iframe_args <- list()
-    iframe_args <- utils::modifyList(iframe_default_args(), iframe_args)
+    iframe_args <- utils::modifyList(iframe_args_default, iframe_args)
+
     iframe_args$srcdoc <- lines
     return(tags$iframe(class = "html-fill-item", !!!iframe_args))
   }
@@ -1778,16 +1785,6 @@ detect_html_document <- function(lines) {
   # and valid, but if the above conditions are met, it's unlikely that we want
   # to treat this document like an HTML fragment.
   TRUE
-}
-
-iframe_default_args <- function() {
-  list(
-    width = "100%",
-    height = "400px",
-    seamless = "seamless",
-    frameBorder = "0",
-    scrolling = "auto"
-  )
 }
 
 #' @note `includeText` escapes its contents, but does no other processing.

--- a/man/include.Rd
+++ b/man/include.Rd
@@ -27,10 +27,10 @@ not an absolute path.}
 \item{iframe_args}{If the HTML document at \code{path} is a complete HTML
 document, the document is included within an \verb{<iframe>}. In this case,
 \code{iframe_args} may include a list of arguments to be passed to
-\code{tags$iframe()}. The default arguments set \code{width}, \code{height},
-\code{frameBorder}, \code{seamless}, and \code{scrolling}. The values in \code{iframe_args}
-will be merged with or will override these defaults. You can unset any of
-the default values by setting them to \code{NULL} in \code{iframe_args}.}
+\code{tags$iframe()}. The default arguments set \code{width}, \code{height}, and
+\code{frameborder}. The values in \code{iframe_args} will be merged with or will
+override these defaults. You can unset any of the default values by setting
+them to \code{NULL} in \code{iframe_args}, e.g. \code{list(frameborder = NULL)}.}
 
 \item{...}{Any additional attributes to be applied to the generated tag.}
 }

--- a/man/include.Rd
+++ b/man/include.Rd
@@ -9,7 +9,7 @@
 \alias{includeScript}
 \title{Include Content From a File}
 \usage{
-includeHTML(path)
+includeHTML(path, iframe_args = NULL)
 
 includeText(path)
 
@@ -23,6 +23,14 @@ includeScript(path, ...)
 \item{path}{The path of the file to be included. It is highly recommended to
 use a relative path (the base path being the Shiny application directory),
 not an absolute path.}
+
+\item{iframe_args}{If the HTML document at \code{path} is a complete HTML
+document, the document is included within an \verb{<iframe>}. In this case,
+\code{iframe_args} may include a list of arguments to be passed to
+\code{tags$iframe()}. The default arguments set \code{width}, \code{height},
+\code{frameBorder}, \code{seamless}, and \code{scrolling}. The values in \code{iframe_args}
+will be merged with or will override these defaults. You can unset any of
+the default values by setting them to \code{NULL} in \code{iframe_args}.}
 
 \item{...}{Any additional attributes to be applied to the generated tag.}
 }


### PR DESCRIPTION
This is a proposal for a fix for #124. It appears that there's a long history of users wanting to call `includeHTML()` to embed arbitrary HTML in a parent document or app, but running into problems when the included HTML is a complete HTML document: https://github.com/rstudio/shiny/issues/2535, https://github.com/rstudio/rmarkdown/issues/1514, https://github.com/rstudio/rmarkdown/issues/792, https://github.com/rstudio/rmarkdown/issues/1514, https://github.com/rstudio/shinydashboard/issues/228, https://github.com/rstudio/shiny/issues/2535, https://github.com/rstudio/htmltools/issues/90.

Our position in the past has been "don't use `includeHTML()` for this", but we also haven't been proactive about preventing the unexpected errors that will occur when a complete HTML document is inlined within another document.

In the majority of cases where users have been historically tempted by `includeHTML()` – primarily when they want to include fully rendered R Markdown or Quarto douments or htmlwidgets – inlining the included HTML document source in an `<iframe>` has been our leading alternative recommendation.

This PR makes that behavior the default. When we detect a complete document, i.e. one that starts with `<!DOCTYPE html>` and ends with `</html>`, we place the HTML document contents in the `srcdoc` attribute of an `<iframe>`. This lets us ship an iframe without having to ship additional files. ([`srcdoc` is well-supported in browsers](https://caniuse.com/iframe-srcdoc).)

## Reprex

The following reprex renders an htmlwidget to a standalone HTML file. It also writes some lorem ipsum text in paragraph tags to a HTML fragment. Both are added in the document with `includeHTML()`.

```r
library(shiny)
library(bslib)
library(leaflet)

# A complete html document containing a leaflet map
tmp_map <- tempfile(fileext = ".html")
map <- leaflet() |>
  addTiles() |>
  setView(-93.65, 42.0285, zoom = 17) |>
  addPopups(-93.65, 42.0285, "Here is the <b>Department of Statistics</b>, ISU")

htmlwidgets::saveWidget(map, tmp_map)

# An HTML fragment, not a complete document
tmp_html <- tempfile(fileext = ".html")
writeLines(format(as.tags(lorem::ipsum(3, 3))), tmp_html)

ui <- page_fluid(
  titlePanel("Hello embedded html in Shiny!"),
  card(
    card_header("A leaflet map, fully encapsulated"),
    full_screen = TRUE,
    includeHTML(tmp_map)
  ),
  h3("Just some more HTML"),
  includeHTML(tmp_html)
)

srv <- function(input, output) {}
shinyApp(ui, srv)
```

![image](https://github.com/rstudio/htmltools/assets/5420529/9e329c7b-7a4f-43f2-8865-caa0368a7690)
