### PR TITLE
feat(html-fill-container): Set min width and height instead of overflow auto

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Closed #124: `includeHTML()` will now issue a warning if it detects that the file passed to it contains a complete HTML document. `includeHTML()` is designed to include HTML fragments where the contents of the file can be written directly into the current app or document, but subtle errors can occur when the file contains a complete HTML document. In most cases, you should instead use `tags$iframe()` to embed external documents. (#382)
 
+* Closed #386: Fillable containers no longer set `overflow: auto` by default. Instead, they set `min-width` and `min-height` to `0` to ensure that fill items a constrained in the fillable container without clipping the fill item container. (#387)
+
 # htmltools 0.5.5
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Closed #124: `includeHTML()` will now issue a warning if it detects that the file passed to it contains a complete HTML document. `includeHTML()` is designed to include HTML fragments where the contents of the file can be written directly into the current app or document, but subtle errors can occur when the file contains a complete HTML document. In most cases, you should instead use `tags$iframe()` to embed external documents. (#382)
 
-* Closed #386: Fillable containers no longer set `overflow: auto` by default. Instead, they set `min-width` and `min-height` to `0` to ensure that fill items a constrained in the fillable container without clipping the fill item container. (#387)
+* Closed #386: Fillable containers no longer set `overflow: auto` by default. Instead, they set `min-width` and `min-height` to `0` to ensure that fill items a constrained in the fillable container without clipping their direct children. (#387)
 
 # htmltools 0.5.5
 

--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -1,8 +1,9 @@
 .html-fill-container {
   display: flex;
   flex-direction: column;
-  overflow: auto;
   width: 100%;
+  min-width: 0;
+  min-height: 0;
 }
 .html-fill-container > .html-fill-item {
   flex: 1 1 auto;

--- a/man/tagQuery.Rd
+++ b/man/tagQuery.Rd
@@ -99,7 +99,7 @@ CSS selector.
 
 \subsection{Reset}{
 \itemize{
-\item \verb{$resetSelected()}: Reset selected tags to the \verb{$root()} tag. Useful
+\item \verb{$resetSelected()}: Reset selected tags to the \verb{$allTags()} tag. Useful
 in combination with \verb{$replaceWith()} since it empties the selection.
 }
 }


### PR DESCRIPTION
Fixes #386

This PR replaces `overflow: auto` on fillable containers (i.e. `.html-fill-container`) with `min-width: 0` and `min-height: 0`. This causes the fillable flex container to resize its contents (in particular to shrink them) correctly without clipping the child container. (See the discussion and reprex in #386.)

<details>
<summary>Reprex</summary>

```r
library(htmltools)
library(bslib)

page_fixed(
  bindFillRole(
    container = TRUE,
    div(
      class = "m-3 float-left",
      style = css(height = "300px", width = "300px"),
      bindFillRole(
        div(class = "border border-2 shadow"),
        item = TRUE
      )
    )
  ),
  bindFillRole(
    container = TRUE,
    div(
      # class = "overflow-visible",
      class = "m-3 float-left",
      style = css(height = "300px", width = "300px"),
      bindFillRole(
        div(class = "border border-2 shadow"),
        item = TRUE
      )
    )
  )
)
```

</details>

![image](https://github.com/rstudio/htmltools/assets/5420529/22f73fd1-de98-46a7-8927-ec6ded4f73c3)

Note that we retain `overflow: auto` on `.html-fill-item`, which means that elements within a fillable item will still cause scrolling, e.g long select input choice menus.