### PR TITLE
feat(fillability): Don't allow shrinking of non-fill items in fillable containers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Closed #386: Fillable containers no longer set `overflow: auto` by default. Instead, they set `min-width` and `min-height` to `0` to ensure that fill items a constrained in the fillable container without clipping their direct children. (#387)
 
+* Closed #370: Non-fill items in fillable containers no longer grow or shrink and instead respect their intrinsic size. Use `height` to control the height of non-fill items in fillable containers and `min-height` and `max-height` on fill items to limit how much they are allowed to grow or shrink within a fillable container. (#391)
+
 # htmltools 0.5.5
 
 ## Bug fixes

--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -6,9 +6,15 @@
   min-height: 0;
 }
 .html-fill-container > .html-fill-item {
+  /* Fill items can grow and shrink freely within
+     available vertical space in fillable container */
   flex: 1 1 auto;
   overflow: auto;
   width: 100%;
+}
+.html-fill-container > :not(.html-fill-item) {
+  /* Prevent shrinking or growing of non-fill items */
+  flex: 0 0 auto;
 }
 .html-fill-container > .html-fill-item.html-fill-item-overflow-hidden {
   overflow: hidden;


### PR DESCRIPTION
Fixes #370 

As currently implemented, both fill items and non-fill items will compete for vertical space in the fillable container's flex context. In the screenshot below (derived from the example in #370), the fillable container has a height of 300px and its contains two children with a set height of 250px. The first child is a fill item and the second child is not. In the current implementation, they equally share the vertical space in the fillable container, thanks to browser defaults of `flex-shrink: 1` allowing overflowing items to shrink in `display: flex`.

![image](https://github.com/rstudio/htmltools/assets/5420529/a873d642-425a-45a9-946c-ad13ee49122a)

This PR changes non-fill item children of fillable containers to have `flex-shrink: 0`, meaning that they'll use their initial height. The  non-fill item in this scenario now has a height of 250px and the fill item shrinks as expected to fill the remaining space.

In general, users should set `min-height` and `max-height` to constrain fill items. This PR doesn't interfere with that advice, but it does mean that setting `height` is now the preferred method for setting the height of a non-fill item. Here's another example, similar to the one above, where the fillable container contains a fill item with `min-height` of `35px`, a non-fill item with `height: 250px` and a fill item without an intrinsic height. Currently, all three share equal space, but in this PR the first fill item uses 35px, the non-fill item uses 250px and the unbounded fill item uses the remaining 15 pixels.

![image](https://github.com/rstudio/htmltools/assets/5420529/d99b06dc-f1a3-41eb-b66c-771ea5f0481a)

Another weird issue this PR avoids is that currently, because the non-fill item is allowed to shrink, its final height is proportional to the overall height of all of the flex children before shrinking. In other words, if we request a height of `100px` for the non-fill item, it currently will have a final height of `50px` (`100 / (250 + 100 + 250) * 300`). After this PR, the non-fill item has the requested `100px` height and the remaining 200 pixels are shared between the fill items.

![image](https://github.com/rstudio/htmltools/assets/5420529/9d19b596-ecc3-4c60-a849-bed619cef2a9)
