### PR TITLE
Remove use of overflow and width in fill container/item css 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # htmltools (development version)
 
+## Improvements
+
+* Fill items no longer set `overflow: auto` or `width: 100%` by default. (#401)
+
 # htmltools 0.5.6
 
 ## Possibly breaking changes

--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -1,6 +1,8 @@
 .html-fill-container {
   display: flex;
   flex-direction: column;
+  /* Prevent the container from expanding vertically or horizontally beyond its
+     parent's constraints. */
   min-height: 0;
   min-width: 0;
 }
@@ -14,7 +16,4 @@
 .html-fill-container > :not(.html-fill-item) {
   /* Prevent shrinking or growing of non-fill items */
   flex: 0 0 auto;
-}
-.html-fill-container > .html-fill-item.html-fill-item-overflow-hidden {
-  overflow: hidden;
 }

--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -9,8 +9,9 @@
   /* Fill items can grow and shrink freely within
      available vertical space in fillable container */
   flex: 1 1 auto;
-  overflow: auto;
   width: 100%;
+  min-width: 0;
+  min-height: 0;
 }
 .html-fill-container > :not(.html-fill-item) {
   /* Prevent shrinking or growing of non-fill items */

--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -1,17 +1,15 @@
 .html-fill-container {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  min-width: 0;
   min-height: 0;
+  min-width: 0;
 }
 .html-fill-container > .html-fill-item {
   /* Fill items can grow and shrink freely within
      available vertical space in fillable container */
   flex: 1 1 auto;
-  width: 100%;
-  min-width: 0;
   min-height: 0;
+  min-width: 0;
 }
 .html-fill-container > :not(.html-fill-item) {
   /* Prevent shrinking or growing of non-fill items */


### PR DESCRIPTION
Closes #399 
Closes #400

### Follow up items

- [ ] Require dev version in htmlwidgets and get rid of it's use of `overflow-hidden`
- [ ] Require dev version in bslib when implementing box-shadow styles