### PR TITLE
fix(css): Don't modify CSS custom properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fill items no longer set `overflow: auto` or `width: 100%` by default. (#401)
 
+* `css()` now fully supports setting custom CSS properties (or CSS variables) via inline styles. When the name of a value passed to `css()` starts with `--`, it will be treated as a custom CSS property and absolutely no changes will be made to the variable. For example, `css("--font_size" = "3em")` returns `--font_size:3em;` while `css(font_size = "3em")` will return `font-size:3em`. (#402)
+
 # htmltools 0.5.6
 
 ## Possibly breaking changes

--- a/R/tags.R
+++ b/R/tags.R
@@ -1950,13 +1950,7 @@ css <- function(..., collapse_ = "") {
   # Translate camelCase, snake_case, and dot.case to kebab-case
   # For standard CSS properties only, not CSS variables
   is_css_var <- grepl("^--", names(props))
-
-  props_std <- names(props)[!is_css_var]
-  props_std <- gsub("([A-Z])", "-\\1", props_std)
-  props_std <- tolower(props_std)
-  props_std <- gsub("[._]", "-", props_std)
-
-  names(props)[!is_css_var] <- props_std
+  names(props)[!is_css_var] <- standardize_property_names(names(props)[!is_css_var])
 
   # Create "!important" suffix for each property whose name ends with !, then
   # remove the ! from the property name
@@ -1968,4 +1962,12 @@ css <- function(..., collapse_ = "") {
 
 empty <- function(x) {
   length(x) == 0 || (is.character(x) && !any(nzchar(x)))
+}
+
+standardize_property_names <- function(x) {
+  # camelCase to kebab-case
+  x <- gsub("([A-Z])", "-\\1", x)
+  x <- tolower(x)
+  # snake_case and dot.case to kebab-case
+  gsub("[._]", "-", x)
 }

--- a/R/tags.R
+++ b/R/tags.R
@@ -1947,8 +1947,16 @@ css <- function(..., collapse_ = "") {
     return(NULL)
   }
 
-  # Replace all '.' and '_' in property names to '-'
-  names(props) <- gsub("[._]", "-", tolower(gsub("([A-Z])", "-\\1", names(props))))
+  # Translate camelCase, snake_case, and dot.case to kebab-case
+  # For standard CSS properties only, not CSS variables
+  is_css_var <- grepl("^--", names(props))
+
+  props_std <- names(props)[!is_css_var]
+  props_std <- gsub("([A-Z])", "-\\1", props_std)
+  props_std <- tolower(props_std)
+  props_std <- gsub("[._]", "-", props_std)
+
+  names(props)[!is_css_var] <- props_std
 
   # Create "!important" suffix for each property whose name ends with !, then
   # remove the ! from the property name

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -847,6 +847,28 @@ test_that("cssList tests", {
     "font-family:Helvetica, \"Segoe UI\";font-size:12px;font-style:italic;font-weight:bold !important;padding:10px 9px 8px;"
   )
 
+  # CSS variables
+  expect_identical(css("--_foo" = "bar"), "--_foo:bar;")
+  expect_identical(css("--fooBar" = "baz"), "--fooBar:baz;")
+  expect_identical(css("--foo_bar" = "baz"), "--foo_bar:baz;")
+  expect_identical(css("--_foo!" = "bar"), "--_foo:bar !important;")
+  expect_identical(css("--fooBar!" = "baz"), "--fooBar:baz !important;")
+  expect_identical(css("--foo_bar!" = "baz"), "--foo_bar:baz !important;")
+
+  # Mix of CSS variables and regular CSS properties
+  expect_identical(
+    css(
+      "--empty" = NULL,
+      "--_foo" = "bar",
+      `_foo` = "bar",
+      "--foo_bar" = "baz",
+      foo_bar = "baz",
+      "--fooBar" = "baz",
+      fooBar = "baz",
+    ),
+    "--_foo:bar;-foo:bar;--foo_bar:baz;foo-bar:baz;--fooBar:baz;foo-bar:baz;"
+  )
+
   # Unnamed args not allowed
   expect_error(css("10"))
   expect_error(css(1, b=2))

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -835,16 +835,28 @@ test_that("Indenting can be controlled/suppressed", {
 test_that("cssList tests", {
   expect_identical(NULL, css())
   expect_identical(NULL, css())
+
+  # Regular CSS properties with conveniences
+  expect_identical(css(font.size = "12px"), "font-size:12px;")
+  expect_identical(css(font_size = "12px"), "font-size:12px;")
+  expect_identical(css(fontSize = "12px"), "font-size:12px;")
+  expect_identical(css(`font-style` = "italic"), "font-style:italic;")
+  expect_null(css(font.variant = NULL))
   expect_identical(
-    css(
-      font.family = 'Helvetica, "Segoe UI"',
-      font_size = "12px",
-      `font-style` = "italic",
-      font.variant = NULL,
-      "font-weight!" = factor("bold"),
-      padding = c("10px", "9px", "8px")
-    ),
-    "font-family:Helvetica, \"Segoe UI\";font-size:12px;font-style:italic;font-weight:bold !important;padding:10px 9px 8px;"
+    css(.webkit.animation = "fade-in 1s"),
+    "-webkit-animation:fade-in 1s;"
+  )
+  expect_identical(
+    css(font.family = 'Helvetica, "Segoe UI"'),
+    "font-family:Helvetica, \"Segoe UI\";"
+  )
+  expect_identical(
+    css("font-weight!" = factor("bold")),
+    "font-weight:bold !important;"
+  )
+  expect_identical(
+    css(padding = c("10px", "9px", "8px")),
+    "padding:10px 9px 8px;"
   )
 
   # CSS variables

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -881,6 +881,12 @@ test_that("cssList tests", {
     "--_foo:bar;-foo:bar;--foo_bar:baz;foo-bar:baz;--fooBar:baz;foo-bar:baz;"
   )
 
+  # Lists can be spliced
+  expect_identical(css(!!!list(a = 1, b = 2)), "a:1;b:2;")
+
+  # Factors are coerced to strings
+  expect_identical(css(a = factor('a')), "a:a;")
+
   # Unnamed args not allowed
   expect_error(css("10"))
   expect_error(css(1, b=2))


### PR DESCRIPTION
Fixes #397

In the CSS spec, custom properties have to start with `--` and thereafter any character is allowed and is used literally: https://www.w3.org/TR/css-variables-1/#defining-variables

This PR updates `css()` to avoid making any changes to CSS properties in any way, while still conveniently converting camelCase, snake_case and dot.case properties (those that don't start with `--`) to kebab-case.

``` r
css(
  font_size = "12px",
  "--_color" = "red",
  "--is_color" = "true",
  "--thisValueIs" = 42
)
#> [1] "font-size:12px;--_color:red;--is_color:true;--thisValueIs:42;"
```