### PR TITLE
Explicitly include NULL as a value that tagQueryFindDescendants_() shouldn't traverse

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `css()` now fully supports setting custom CSS properties (or CSS variables) via inline styles. When the name of a value passed to `css()` starts with `--`, it will be treated as a custom CSS property and absolutely no changes will be made to the variable. For example, `css("--font_size" = "3em")` returns `--font_size:3em;` while `css(font_size = "3em")` will return `font-size:3em`. (#402)
 
+* `tagQuery()` no longer throws an error when attempting to traverse a NULL value with r-devel. (#407)
+
 ## Bug fixes
 
 * `{htmltools}` now requires `{rlang}` version 1.0.0 or higher. (#403)

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1532,7 +1532,7 @@ tagQueryFindDescendants_ <- function(el, selector, fn) {
   } else if (is.list(el)) {
     # For each item in the list like object, recurse through
     walk(el, tagQueryFindDescendants_, fn = fn, selector = selector)
-  } else if (is.atomic(el) || is.function(el) || is.language(el)) {
+  } else if (is.null(el) || is.atomic(el) || is.function(el) || is.language(el)) {
     # Can not match on atomics or functions
     return()
   } else {


### PR DESCRIPTION
Closes #407. 