### PR TITLE
v0.5.7 release candidate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: htmltools
 Type: Package
 Title: Tools for HTML
-Version: 0.5.6
+Version: 0.5.7
 Authors@R: c(
   person("Joe", "Cheng", role = "aut", email = "joe@posit.co"),
   person("Carson", "Sievert", role = c("aut", "cre"), email = "carson@posit.co", comment = c(ORCID = "0000-0002-4958-2844")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# htmltools 0.5.7
+
+## Improvements
+
+* `tagQuery()` no longer throws an error when attempting to traverse a NULL value with r-devel. (#407)
+
 # htmltools 0.5.6
 
 ## Possibly breaking changes

--- a/R/tag_query.R
+++ b/R/tag_query.R
@@ -1532,7 +1532,7 @@ tagQueryFindDescendants_ <- function(el, selector, fn) {
   } else if (is.list(el)) {
     # For each item in the list like object, recurse through
     walk(el, tagQueryFindDescendants_, fn = fn, selector = selector)
-  } else if (is.atomic(el) || is.function(el) || is.language(el)) {
+  } else if (is.null(el) || is.atomic(el) || is.function(el) || is.language(el)) {
     # Can not match on atomics or functions
     return()
   } else {

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,19 +1,21 @@
 # Revdeps
 
-## Failed to check (12)
+## Failed to check (14)
 
-|package |version |error |warning |note |
-|:-------|:-------|:-----|:-------|:----|
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|grandR  |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
-|NA      |?       |      |        |     |
+|package   |version |error |warning |note |
+|:---------|:-------|:-----|:-------|:----|
+|NA        |?       |      |        |     |
+|checkdown |0.0.10  |1     |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|grandR    |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
+|NA        |?       |      |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,12 +1,13 @@
 ## revdepcheck results
 
-We checked 467 reverse dependencies (456 from CRAN + 11 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 479 reverse dependencies (467 from CRAN + 12 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
- * We failed to check 1 packages
+ * We failed to check 2 packages
 
 Issues with CRAN packages are summarised below.
 
 ### Failed to check
 
-* grandR (NA)
+* checkdown (NA)
+* grandR    (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -33,6 +33,64 @@ Run `revdepcheck::cloud_details(, "NA")` for more info
 
 
 ```
+# checkdown
+
+<details>
+
+* Version: 0.0.10
+* GitHub: https://github.com/agricolamz/checkdown
+* Source code: https://github.com/cran/checkdown
+* Date/Publication: 2023-09-24 07:10:02 UTC
+* Number of recursive dependencies: 33
+
+Run `revdepcheck::cloud_details(, "checkdown")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘checkdown’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/checkdown/new/checkdown.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘checkdown’ ...
+** package ‘checkdown’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+Error in parse(outFile) : 
+  /tmp/workdir/checkdown/new/checkdown.Rcheck/00_pkg_src/checkdown/R/check_hint.R:38:39: unexpected input
+37:   hint_text <- hint_text |>
+38:       markdown::markdownToHTML(text = _
+                                          ^
+ERROR: unable to collate and parse R files for package ‘checkdown’
+* removing ‘/tmp/workdir/checkdown/new/checkdown.Rcheck/checkdown’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘checkdown’ ...
+** package ‘checkdown’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+Error in parse(outFile) : 
+  /tmp/workdir/checkdown/old/checkdown.Rcheck/00_pkg_src/checkdown/R/check_hint.R:38:39: unexpected input
+37:   hint_text <- hint_text |>
+38:       markdown::markdownToHTML(text = _
+                                          ^
+ERROR: unable to collate and parse R files for package ‘checkdown’
+* removing ‘/tmp/workdir/checkdown/old/checkdown.Rcheck/checkdown’
+
+
+```
 # NA
 
 <details>
@@ -173,6 +231,41 @@ Status: 2 NOTEs
 * checking re-building of vignette outputs ... OK
 * DONE
 Status: 2 NOTEs
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* GitHub: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `revdepcheck::cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
 
 
 


### PR DESCRIPTION
Closes #409 

This patch release branches off the `v0.5.6` tag to only include #408 (since CRAN has requested a fix by Oct 14). Some of the other changes on main should be done in coordination with a `{bslib}` release, which may not happen until later Oct. 