### PR TITLE
Improve performance of tags functions

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -170,7 +170,12 @@ nullOrEmpty <- function(x) {
 
 # Given a vector or list, drop all the NULL or length-0 items in it
 dropNullsOrEmpty <- function(x) {
-  x[!vapply(x, nullOrEmpty, FUN.VALUE=logical(1))]
+  ns <- lengths(x) == 0
+  if (any(ns)) {
+    x <- x[!ns]
+  }
+
+  x
 }
 
 isResolvedTag <- function(x) {
@@ -674,7 +679,6 @@ tags <- lapply(known_tags, function(tagname) {
   new_function(
     args = exprs(... = , .noWS = NULL, .renderHook = NULL),
     expr({
-      validateNoWS(.noWS)
       contents <- dots_list(...)
       tag(!!tagname, contents, .noWS = .noWS, .renderHook = .renderHook)
     }),
@@ -800,7 +804,8 @@ tag <- function(`_tag_name`, varArgs, .noWS = NULL, .renderHook = NULL) {
   }
 
   # Return tag data structure
-  structure(st, class = "shiny.tag")
+  class(st) <- "shiny.tag"
+  st
 }
 
 isTagList <- function(x) {


### PR DESCRIPTION
Functions like `tags$tr()` can easily be a little faster.

```r
library(htmltools)

set.seed(1)
n <- 50e3
data <- vroom::gen_character(n)

f <- function(data) {
  for (i in seq_along(data)) {
    tags$tr(data[[i]])
  }
}

bench::mark(f(data))

# before
# # A tibble: 1 × 13
#   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
#   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
# 1 f(data)       1.37s    1.37s     0.730    41.2KB     27.8     1    38      1.37s

# after
# # A tibble: 1 × 13
#   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
#   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
# 1 f(data)       830ms    830ms      1.20    30.1KB     30.1     1    25      830ms
```