### PR TITLE
`bindFillRole()` should attach its `HTMLDependency()` to fill items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # htmltools (development version)
 
+## Bug fixes
+
+* `bindFillRole()` now attaches its `HTMLDependency()` to fill items, thus reducing the possibility of filling layout breaking due to missing CSS. (#421) 
+
+
 # htmltools 0.5.7
 
 ## New Features

--- a/R/fill.R
+++ b/R/fill.R
@@ -91,7 +91,7 @@ bindFillRole <- function(x, ..., item = FALSE, container = FALSE, overwrite = FA
     class = if (container) "html-fill-container"
   )
 
-  if (container) {
+  if (container || item) {
     x <- attachDependencies(x, fillDependencies(), append = TRUE)
   }
 

--- a/tests/testthat/test-fill.R
+++ b/tests/testthat/test-fill.R
@@ -8,11 +8,13 @@ test_that("asFillContainer() and asFillItem()", {
   expect_true(
     doRenderTags(x) == "<div class=\"html-fill-container\"></div>"
   )
+  expect_equal(htmlDependencies(x), list(fillDependencies()))
 
   x <- bindFillRole(div(), item = TRUE)
   expect_true(
     doRenderTags(x) == "<div class=\"html-fill-item\"></div>"
   )
+  expect_equal(htmlDependencies(x), list(fillDependencies()))
 
   x <- bindFillRole(x, container = TRUE, overwrite = TRUE)
   expect_true(


### PR DESCRIPTION
With this change, something like this now works:

```r
div(class = "html-fill-container", bindFillRole(div(), item = TRUE))
```

The importance of which has increased since the emergence of `div(bslib::as_fillable_container())`, which only adds the HTML classes (not the dependencies).

And since `bslib::page_fillable()` uses `as_fillable_container()`, this currently doesn't work:

```r
library(shiny)
library(plotly)
library(bslib)

ui <- page_fillable(
  plotlyOutput("p")
)

server <- function(input, output) {
  output$p <- renderPlotly({
    plotly::plot_ly()
  })
}

shinyApp(ui, server)
```