### PR TITLE
Remove dependency on ellipsis.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Depends:
 Imports:
     base64enc,
     digest,
-    ellipsis,
     fastmap (>= 1.1.0),
     grDevices,
     rlang (>= 1.0.0),

--- a/R/fill.R
+++ b/R/fill.R
@@ -51,7 +51,7 @@
 #'
 bindFillRole <- function(x, ..., item = FALSE, container = FALSE, overwrite = FALSE, .cssSelector = NULL) {
 
-  ellipsis::check_dots_empty()
+  check_dots_empty()
 
   hasSelection <- FALSE
   query <- NULL


### PR DESCRIPTION
Replace ellipsis::check_dots_empty() by rlang::check_dots_empty()

Since there is `#' @import rlang`, removing ns suffices, as rlang has check_dots_empty()