### PR TITLE
feat(fill): Use a `@layer htmltools`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Config/Needs/check: knitr
 Config/Needs/website: rstudio/quillt, bench
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Collate:
     'colors.R'
     'fill.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 # htmltools (development version)
 
+## Improvements
+
+* The fill CSS attached to fillable containers and fill items with `bindFillRole()` now uses a [CSS cascade layer](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Cascade_layers) named `htmltools` to reduce the precedence order of the fill CSS. (#425)
+
 ## Bug fixes
 
-* `bindFillRole()` now attaches its `HTMLDependency()` to fill items, thus reducing the possibility of filling layout breaking due to missing CSS. (#421) 
+* `bindFillRole()` now attaches its `HTMLDependency()` to fill items, thus reducing the possibility of filling layout breaking due to missing CSS. (#421)
 
 
 # htmltools 0.5.7

--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -1,19 +1,21 @@
-.html-fill-container {
-  display: flex;
-  flex-direction: column;
-  /* Prevent the container from expanding vertically or horizontally beyond its
-     parent's constraints. */
-  min-height: 0;
-  min-width: 0;
-}
-.html-fill-container > .html-fill-item {
-  /* Fill items can grow and shrink freely within
-     available vertical space in fillable container */
-  flex: 1 1 auto;
-  min-height: 0;
-  min-width: 0;
-}
-.html-fill-container > :not(.html-fill-item) {
-  /* Prevent shrinking or growing of non-fill items */
-  flex: 0 0 auto;
+@layer htmltools {
+  .html-fill-container {
+    display: flex;
+    flex-direction: column;
+    /* Prevent the container from expanding vertically or horizontally beyond its
+    parent's constraints. */
+    min-height: 0;
+    min-width: 0;
+  }
+  .html-fill-container > .html-fill-item {
+    /* Fill items can grow and shrink freely within
+    available vertical space in fillable container */
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+  }
+  .html-fill-container > :not(.html-fill-item) {
+    /* Prevent shrinking or growing of non-fill items */
+    flex: 0 0 auto;
+  }
 }


### PR DESCRIPTION
This PR wraps the `fill.css` rules in a `@layer htmltools`.

In bslib we have the following CSS rule using the `.bslib-flow-mobile` class:

```scss
@include media-breakpoint-down(sm) {
  .bslib-flow-mobile > .html-fill-item {
    flex: 0 0 auto;
  }
}
```

This rule is intended to undo the `fill.css` rule

```css
.html-fill-container > .html-fill-item {
  flex: 1 1 auto;
}
```

but it has a specificity problem where whether or not it is applied as expected depends on the order in which dependencies are loaded. 

In fact, it appears that currently `.bslib-flow-mobile` is applied correctly in Shiny for Python and not in Shiny for R where `page_fillable()` appears to be always filling on mobile with dev bslib (we started including the component CSS in `bs_theme_dependency()` in https://github.com/rstudio/bslib/pull/810).


One obvious fix is to increase the specificity of the `.bslib-flow-mobile` rule (and we may still want to do this to avoid version coordination between bslib and htmltools).

```scss
@include media-breakpoint-down(sm) {
  .bslib-flow-mobile.html-fill-container > .html-fill-item {
    flex: 0 0 auto;
  }
}
```

But we generally intend for `fill.css` to be applied at a lower level than other CSS rules. We've also talked about adopting CSS layers in our dependencies. Fortunately, we can start using a layer for `fill.css` without having to completely work out how we'll use layers overall.

I'm proposing we use the package name, `@layer htmltools`, for this layer, rather than trying to guess what functional-oriented name we might want in the long run (e.g. `utilities` or `layout`, etc.). We also don't need to declare layer order elsewhere, simply using a layer is enough to at least reduce the importance of these rules. At some point we may decide to have bslib coordinate some of the layer ordering, but we don't need to do that now.