### PR TITLE
Add example of using style in tagList()

### DIFF
--- a/R/tags.R
+++ b/R/tags.R
@@ -268,7 +268,7 @@ normalizeText <- function(text) {
 #' @examples
 #' tagList(
 #'   h1("Title"),
-#'   h2("Header text"),
+#'   h2("Header text", style = "text-align: center;"),
 #'   p("Text here")
 #' )
 tagList <- function(...) {

--- a/R/tags.R
+++ b/R/tags.R
@@ -268,7 +268,7 @@ normalizeText <- function(text) {
 #' @examples
 #' tagList(
 #'   h1("Title"),
-#'   h2("Header text", style = "text-align: center;"),
+#'   h2("Header text", style = "color: red;"),
 #'   p("Text here")
 #' )
 tagList <- function(...) {

--- a/man/tagList.Rd
+++ b/man/tagList.Rd
@@ -16,7 +16,7 @@ etc.
 \examples{
 tagList(
   h1("Title"),
-  h2("Header text"),
+  h2("Header text", style = "color: red;"),
   p("Text here")
 )
 }


### PR DESCRIPTION
Just a little edit to the doc to make it clearer you can add attributes / style by supplying named arguments to tags

Relates a bit to #431. I had to do a github search to see examples of usage of the tags. The `?builder` page also lacks documentation of `class` and `style`, maybe could be added in the docs of `...` there too..