### PR TITLE
fix(fill): remove ui/text outputs from document flow

### DIFF
--- a/inst/fill/fill.css
+++ b/inst/fill/fill.css
@@ -2,14 +2,14 @@
   .html-fill-container {
     display: flex;
     flex-direction: column;
-    /* Prevent the container from expanding vertically or horizontally beyond its
-    parent's constraints. */
+    /* Prevent the container from expanding vertically or horizontally beyond
+     * its parent's constraints. */
     min-height: 0;
     min-width: 0;
   }
   .html-fill-container > .html-fill-item {
-    /* Fill items can grow and shrink freely within
-    available vertical space in fillable container */
+    /* Fill items can grow and shrink freely within available vertical space in
+     * fillable container */
     flex: 1 1 auto;
     min-height: 0;
     min-width: 0;
@@ -17,5 +17,11 @@
   .html-fill-container > :not(.html-fill-item) {
     /* Prevent shrinking or growing of non-fill items */
     flex: 0 0 auto;
+  }
+  .html-fill-container > .shiny-html-output:empty,
+  .html-fill-container > .shiny-text-output:empty {
+    /* Remove empty ui and text outputs from the document flow so that extra
+     * space in the flex container is not allocated for them. */
+    position: absolute
   }
 }


### PR DESCRIPTION
Fixes #1629

When `uiOutput()` or `textOutut()` are used in a fillable container but are empty, users expect that those elements are entirely invisible or completely removed. In a `display: flex` context, however, empty divs are still included in the allocation of space.

<details><summary>Example app</summary>

```r
library(shiny)
library(bslib)
# pkgload::load_all()

ui <- page_fillable(
  card(
    card_header("A"),
    input_switch("show_card_b", "Show card B", value = FALSE),
    input_switch("show_text", "Show text", value = FALSE)
  ),
  uiOutput("card_b"),
  textOutput("text"),
  card(card_header("D"))
)

server <- function(input, output, session) {
  output$card_b <- renderUI({
    req(input$show_card_b)
    card(card_header("B"))
  })

  output$text <- renderText({
    req(input$show_text)
    "This text gets regular spacing."
  })
}

shinyApp(ui, server)
```

</details>