### PR TITLE
Fix for upcoming testthat 3.3.0

### DIFF
--- a/tests/testthat/test-tag-query.R
+++ b/tests/testthat/test-tag-query.R
@@ -120,11 +120,12 @@ test_that("tagQuery()$find()", {
 
   # Make sure the found elements do not persist
   newX <- x$find("span")
-  expect_failure(
+  expect_condition(
     expect_equal_tags(
       x$selectedTags(),
       newX$selectedTags()
-    )
+    ),
+    class = "expectation_failure"
   )
 
   x <- x$find("span")


### PR DESCRIPTION
`expect_failure()` has gotten much stricter so this is a quick fix to make sure R CMD check doesn't fail. Making `expect_tag_equal()` be a real expectation would be better, but quite a bit of work.