### PR TITLE
Update digest package dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Depends:
     R (>= 2.14.1)
 Imports:
     base64enc,
-    digest,
+    digest (>= 0.6.37),
     fastmap (>= 1.1.0),
     grDevices,
     rlang (>= 1.0.0),


### PR DESCRIPTION
Adding the digest package version requirement 0.6.37.

I was investigating some dependency of package formatters, and I ran into problem with this build

https://github.com/insightsengineering/formatters/actions/runs/20563614119/job/59058035025

it complains about the installation of digest, 0.6.36 had problem from installation, and the dependency tracked down to the line 

https://github.com/insightsengineering/formatters/actions/runs/20563614119/job/59058035025#step:9:762

```
│ ├─htmltools 0.5.8.1 [new]
│ │ ├─base64enc
│ │ ├─digest 0.6.36 [new][bld][cmp]
│ │ ├─fastmap 1.2.0 [new]
│ │ └─rlang
```

```
✖ Failed to build digest 0.6.36 (3.4s)
! Failed to build source package digest., stdout + stderr:

OE> * installing *source* package ‘digest’ ...
OE> ** this is package ‘digest’ version ‘0.6.36’
OE> ** package ‘digest’ successfully unpacked and MD5 sums checked
OE> staged installation is only possible with locking
OE> ** using non-staged installation
OE> ** libs
OE> using C compiler: ‘gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
OE> using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
OE> g++ -std=gnu++17 -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic  -c SpookyV2.cpp -o SpookyV2.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c aes.c -o aes.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c blake3.c -o blake3.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c blake3_dispatch.c -o blake3_dispatch.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c blake3_portable.c -o blake3_portable.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c crc32.c -o crc32.o
OE> g++ -std=gnu++17 -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic  -c crc32c.cpp -o crc32c.o
OE> g++ -std=gnu++17 -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic  -c crc32c_portable.cpp -o crc32c_portable.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c digest.c -o digest.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c digest2int.c -o digest2int.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c init.c -o init.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c md5.c -o md5.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c pmurhash.c -o pmurhash.o
OE> gcc -std=gnu2x -I"/usr/local/lib/R/include" -DNDEBUG -I.  -I/usr/local/include    -fpic  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -Wall -pedantic -c raes.c -o raes.o
OE> raes.c: In function ‘AESFinalizer’:
OE> raes.c:25:3: warning: implicit declaration of function ‘Free’; did you mean ‘free’? [-Wimplicit-function-declaration]
Error in "stop_task_build(state, worker)" : 
  ! Failed to build source package digest.
OE>    25 |   Free(ctx);
OE>       |   ^~~~
OE>       |   free
OE> raes.c: In function ‘AESinit’:
OE> raes.c:42:23: warning: implicit declaration of function ‘Calloc’; did you mean ‘calloc’? [-Wimplicit-function-declaration]
OE>    42 |   ctx = (aes_context*)Calloc(sizeof(*ctx), char);
OE>       |                       ^~~~~~
OE>       |                       calloc
OE> raes.c:42:44: error: expected expression before ‘char’
OE>    42 |   ctx = (aes_context*)Calloc(sizeof(*ctx), char);
OE>       |                                            ^~~~
OE> make: *** [/usr/local/lib/R/etc/Makeconf:202: raes.o] Error 1
OE> ERROR: compilation failed for package ‘digest’
OE> * removing ‘/tmp/Rtmpm2RqlQ/pkg-libc2645cc606/digest’
```

0.6.37 seems to work fine. Would love to make a small suggestion here to help user installation experience. Thank you!