### PR TITLE
Clearer error when include*() helpers are given a missing file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # htmltools (development version)
 
-* `includeCSS()` now raises a clear error naming the missing file when `path` does not exist, instead of the vague "cannot open the connection" message from `readLines()`. (rstudio/shiny#1757)
+* `includeCSS()`, `includeHTML()`, `includeText()`, `includeMarkdown()`, and `includeScript()` now raise a clear error naming the missing file when `path` does not exist, instead of the vague "cannot open the connection" message from `readLines()`. (rstudio/shiny#1757)
 
 # htmltools 0.5.9
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # htmltools (development version)
 
+* `includeCSS()` now raises a clear error naming the missing file when `path` does not exist, instead of the vague "cannot open the connection" message from `readLines()`. (rstudio/shiny#1757)
+
 # htmltools 0.5.9
 
 * Fix test for testthat 3.3.0. (#442) 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `includeCSS()`, `includeHTML()`, `includeText()`, `includeMarkdown()`, and `includeScript()` now raise a clear error naming the missing file when `path` does not exist, instead of the vague "cannot open the connection" message from `readLines()`. (rstudio/shiny#1757)
 
+
 # htmltools 0.5.9
 
 * Fix test for testthat 3.3.0. (#442) 

--- a/R/tags.R
+++ b/R/tags.R
@@ -1733,6 +1733,7 @@ knit_print.html_dependency <- knit_print.shiny.tag
 #' @aliases includeHTML
 #' @export
 includeHTML <- function(path) {
+  check_include_path(path, "HTML file")
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
 
   if (detect_html_document(lines)) {
@@ -1781,6 +1782,7 @@ detect_html_document <- function(lines) {
 #' @rdname include
 #' @export
 includeText <- function(path) {
+  check_include_path(path, "Text file")
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
   return(paste8(lines, collapse='\n'))
 }
@@ -1790,6 +1792,7 @@ includeText <- function(path) {
 #' @rdname include
 #' @export
 includeMarkdown <- function(path) {
+  check_include_path(path, "Markdown file")
   # markdown >= v1.3 switched from markdownToHTML() to mark()
   html <- if (packageVersion("markdown") < "1.3") {
     markdown::markdownToHTML(path, fragment.only = TRUE)
@@ -1804,12 +1807,7 @@ includeMarkdown <- function(path) {
 #' @rdname include
 #' @export
 includeCSS <- function(path, ...) {
-  if (!file.exists(path)) {
-    rlang::abort(c(
-      "CSS file does not exist.",
-      "x" = paste0("Path: ", path)
-    ))
-  }
+  check_include_path(path, "CSS file")
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
   args <- dots_list(...)
   if (is.null(args$type))
@@ -1821,8 +1819,18 @@ includeCSS <- function(path, ...) {
 #' @rdname include
 #' @export
 includeScript <- function(path, ...) {
+  check_include_path(path, "Script file")
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
   return(tags$script(HTML(paste8(lines, collapse='\n')), ...))
+}
+
+check_include_path <- function(path, what = "File") {
+  if (!file.exists(path)) {
+    rlang::abort(c(
+      paste0(what, " does not exist."),
+      "x" = paste0("Path: ", path)
+    ))
+  }
 }
 
 #' Include content only once

--- a/R/tags.R
+++ b/R/tags.R
@@ -1804,6 +1804,12 @@ includeMarkdown <- function(path) {
 #' @rdname include
 #' @export
 includeCSS <- function(path, ...) {
+  if (!file.exists(path)) {
+    rlang::abort(c(
+      "CSS file does not exist.",
+      "x" = paste0("Path: ", path)
+    ))
+  }
   lines <- readLines(path, warn=FALSE, encoding='UTF-8')
   args <- dots_list(...)
   if (is.null(args$type))

--- a/R/tags.R
+++ b/R/tags.R
@@ -1824,12 +1824,15 @@ includeScript <- function(path, ...) {
   return(tags$script(HTML(paste8(lines, collapse='\n')), ...))
 }
 
-check_include_path <- function(path, what = "File") {
+check_include_path <- function(path, what = "File", call = rlang::caller_env()) {
   if (!file.exists(path)) {
-    rlang::abort(c(
-      paste0(what, " does not exist."),
-      "x" = paste0("Path: ", path)
-    ))
+    rlang::abort(
+      c(
+        paste0(what, " does not exist."),
+        "x" = paste0("Path: ", path)
+      ),
+      call = call
+    )
   }
 }
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -1825,7 +1825,13 @@ includeScript <- function(path, ...) {
 }
 
 check_include_path <- function(path, what = "File", call = rlang::caller_env()) {
-  if (!file.exists(path)) {
+  if (!rlang::is_string(path) || !nzchar(path)) {
+    rlang::abort(
+      paste0(what, " path must be a single non-empty string."),
+      call = call
+    )
+  }
+  if (!file.exists(path) || dir.exists(path)) {
     rlang::abort(
       c(
         paste0(what, " does not exist."),

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -1242,3 +1242,9 @@ test_that("includeMarkdown() raises a clear error when the file is missing", {
   missing <- tempfile("does-not-exist-", fileext = ".txt")
   expect_error(includeMarkdown(missing), "Markdown file does not exist")
 })
+
+test_that("include*() missing-file error is attributed to the public helper", {
+  missing <- tempfile("does-not-exist-", fileext = ".txt")
+  err <- rlang::catch_cnd(includeCSS(missing))
+  expect_match(rlang::expr_deparse(err$call), "includeCSS")
+})

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -1226,3 +1226,20 @@ test_that("includeHTML() warns if full document is detected", {
   save_html(p("test"), tmp_html)
   expect_warning(includeHTML(tmp_html))
 })
+
+test_that("include*() helpers raise a clear error when the file is missing", {
+  missing <- tempfile("does-not-exist-", fileext = ".txt")
+  expect_false(file.exists(missing))
+
+  expect_error(includeCSS(missing),      "CSS file does not exist")
+  expect_error(includeHTML(missing),     "HTML file does not exist")
+  expect_error(includeText(missing),     "Text file does not exist")
+  expect_error(includeScript(missing),   "Script file does not exist")
+  skip_if_not_installed("markdown")
+  expect_error(includeMarkdown(missing), "Markdown file does not exist")
+})
+
+test_that("include*() error message names the missing path", {
+  missing <- tempfile("does-not-exist-", fileext = ".txt")
+  expect_error(includeCSS(missing), missing, fixed = TRUE)
+})

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -1231,15 +1231,14 @@ test_that("include*() helpers raise a clear error when the file is missing", {
   missing <- tempfile("does-not-exist-", fileext = ".txt")
   expect_false(file.exists(missing))
 
-  expect_error(includeCSS(missing),      "CSS file does not exist")
-  expect_error(includeHTML(missing),     "HTML file does not exist")
-  expect_error(includeText(missing),     "Text file does not exist")
-  expect_error(includeScript(missing),   "Script file does not exist")
-  skip_if_not_installed("markdown")
-  expect_error(includeMarkdown(missing), "Markdown file does not exist")
+  expect_error(includeCSS(missing),    "CSS file does not exist")
+  expect_error(includeHTML(missing),   "HTML file does not exist")
+  expect_error(includeText(missing),   "Text file does not exist")
+  expect_error(includeScript(missing), "Script file does not exist")
 })
 
-test_that("include*() error message names the missing path", {
+test_that("includeMarkdown() raises a clear error when the file is missing", {
+  skip_if_not_installed("markdown")
   missing <- tempfile("does-not-exist-", fileext = ".txt")
-  expect_error(includeCSS(missing), missing, fixed = TRUE)
+  expect_error(includeMarkdown(missing), "Markdown file does not exist")
 })

--- a/tests/testthat/test-tags.r
+++ b/tests/testthat/test-tags.r
@@ -1248,3 +1248,17 @@ test_that("include*() missing-file error is attributed to the public helper", {
   err <- rlang::catch_cnd(includeCSS(missing))
   expect_match(rlang::expr_deparse(err$call), "includeCSS")
 })
+
+test_that("include*() helpers reject invalid path inputs", {
+  expect_error(includeCSS(NULL),         "must be a single non-empty string")
+  expect_error(includeCSS(character(0)), "must be a single non-empty string")
+  expect_error(includeCSS(c("a", "b")),  "must be a single non-empty string")
+  expect_error(includeCSS(""),           "must be a single non-empty string")
+  expect_error(includeCSS(NA_character_), "must be a single non-empty string")
+})
+
+test_that("include*() helpers reject a directory path", {
+  dir <- withr::local_tempdir()
+  expect_true(dir.exists(dir))
+  expect_error(includeCSS(dir), "CSS file does not exist")
+})


### PR DESCRIPTION
Fixes rstudio/shiny#1757

## Summary

- `includeCSS()`, `includeHTML()`, `includeText()`, `includeMarkdown()`, and `includeScript()` previously surfaced the generic `cannot open the connection` message from `readLines()` when given a non-existent `path`.
- This PR adds an up-front `file.exists()` check via a new internal helper `check_include_path()`, which raises a structured `rlang::abort()` naming the missing file.
- `NEWS.md` updated.

## Test plan

- [ ] `devtools::test()` passes
- [ ] Manually verify each helper raises the new error when given a missing path
- [ ] Manually verify each helper still works for an existing file