### PR TITLE
fix: avoid Suggests-only packages in tests and examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,9 +39,9 @@ Enhances:
     knitr
 Config/Needs/check: knitr
 Config/Needs/website: rstudio/quillt, bench
+Config/roxygen2/version: 8.0.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Collate:
     'colors.R'
     'fill.R'

--- a/R/tags.R
+++ b/R/tags.R
@@ -299,7 +299,9 @@ tagList <- function(...) {
 #' })
 #' myDiv <- attachDependencies(div(), myDivDep)
 #' renderTags(myDiv)
-#' withr::with_options(list(useDep = FALSE), renderTags(myDiv))
+#' if (requireNamespace("withr", quietly = TRUE)) {
+#'   withr::with_options(list(useDep = FALSE), renderTags(myDiv))
+#' }
 #'
 tagFunction <- function(func) {
   if (!is.function(func) || length(formals(func)) != 0) {

--- a/man/capturePlot.Rd
+++ b/man/capturePlot.Rd
@@ -24,7 +24,7 @@ extension will be used; you should provide a filename with a different
 extension if you provide a non-PNG graphics device function.}
 
 \item{device}{A graphics device function; by default, this will be either
-\code{\link[grDevices:png]{grDevices::png()}}, \code{\link[ragg:agg_png]{ragg::agg_png()}}, or \code{\link[Cairo:Cairo]{Cairo::CairoPNG()}}, depending on
+\code{\link[grDevices:png]{grDevices::png()}}, \code{\link[ragg:agg_png]{ragg::agg_png()}}, or \code{\link[Cairo:CairoPNG]{Cairo::CairoPNG()}}, depending on
 your system and configuration. See \code{\link[=defaultPngDevice]{defaultPngDevice()}}.}
 
 \item{width, height, res, ...}{Additional arguments to the \code{device} function.}

--- a/man/defaultPngDevice.Rd
+++ b/man/defaultPngDevice.Rd
@@ -14,7 +14,7 @@ Returns the best PNG-based graphics device for your system, in the opinion of
 the \code{htmltools} maintainers. On Mac,
 \code{\link[grDevices:png]{grDevices::png()}} is used; on all other
 platforms, either \code{\link[ragg:agg_png]{ragg::agg_png()}} or
-\code{\link[Cairo:Cairo]{Cairo::CairoPNG()}} are used if their packages
+\code{\link[Cairo:CairoPNG]{Cairo::CairoPNG()}} are used if their packages
 are installed. Otherwise, \code{\link[grDevices:png]{grDevices::png()}} is
 used.
 }

--- a/man/htmltools-package.Rd
+++ b/man/htmltools-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Carson Sievert \email{carson@posit.co} (\href{https://orcid.org/0000-0002-4958-2844}{ORCID})
   \item Joe Cheng \email{joe@posit.co}
   \item Barret Schloerke \email{barret@posit.co} (\href{https://orcid.org/0000-0001-9986-114X}{ORCID})
   \item Winston Chang \email{winston@posit.co} (\href{https://orcid.org/0000-0002-1576-2126}{ORCID})

--- a/man/plotTag.Rd
+++ b/man/plotTag.Rd
@@ -26,7 +26,7 @@ of the image. This is used by accessibility tools, such as screen readers
 for vision impaired users.}
 
 \item{device}{A graphics device function; by default, this will be either
-\code{\link[grDevices:png]{grDevices::png()}}, \code{\link[ragg:agg_png]{ragg::agg_png()}}, or \code{\link[Cairo:Cairo]{Cairo::CairoPNG()}}, depending on
+\code{\link[grDevices:png]{grDevices::png()}}, \code{\link[ragg:agg_png]{ragg::agg_png()}}, or \code{\link[Cairo:CairoPNG]{Cairo::CairoPNG()}}, depending on
 your system and configuration. See \code{\link[=defaultPngDevice]{defaultPngDevice()}}.}
 
 \item{width, height}{The width/height that the generated tag should be
@@ -35,7 +35,7 @@ displayed at, in logical (browser) pixels.}
 \item{pixelratio}{Indicates the ratio between physical and logical units of
 length. For PNGs that may be displayed on high-DPI screens, use \code{2};
 for graphics devices that express width/height in inches (like
-\code{\link[grDevices:cairo]{grDevices::svg()}}, try \code{1/72} or \code{1/96}.}
+\code{\link[grDevices:svg]{grDevices::svg()}}, try \code{1/72} or \code{1/96}.}
 
 \item{mimeType}{The MIME type associated with the \code{device}. Examples are
 \code{image/png}, \code{image/tiff}, \code{image/svg+xml}.}

--- a/man/tagFunction.Rd
+++ b/man/tagFunction.Rd
@@ -28,7 +28,9 @@ myDivDep <- tagFunction(function() {
 })
 myDiv <- attachDependencies(div(), myDivDep)
 renderTags(myDiv)
-withr::with_options(list(useDep = FALSE), renderTags(myDiv))
+if (requireNamespace("withr", quietly = TRUE)) {
+  withr::with_options(list(useDep = FALSE), renderTags(myDiv))
+}
 
 }
 \seealso{

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -19,6 +19,7 @@ test_that("print.html preserves dependencies for HTML()", {
 })
 
 test_that("CRLF is properly handled", {
+  skip_if_not_installed("markdown")
   txt <- paste(c("x", "y", ""), collapse = "\r\n")
 
   tmp <- tempfile(fileext = ".txt")


### PR DESCRIPTION
## Summary

Fix two failures in the depends-only R CMD check, where only `Depends`/`Imports` packages are installed:

- `tests/testthat/test-print.R`: skip the `CRLF is properly handled` test when the Suggests-only `markdown` package isn't installed (the test calls `includeMarkdown()`, which requires it).
- `R/tags.R`: guard the `withr::with_options()` call in the `tagFunction()` example with `if (requireNamespace("withr", quietly = TRUE))` so the example runs when `withr` is available and is skipped otherwise.

Also regenerates the man pages with roxygen2 8.0.0 (replacing `RoxygenNote` with `Config/roxygen2/version` in `DESCRIPTION`).

## Test plan

- [ ] `R-CMD-check / check-depends-only` passes
- [ ] Other R-CMD-check matrix jobs pass