### PR TITLE
Fix .noWS documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # htmltools (development version)
 
+* The `.noWS` documentation now lists `inside` for tags and correctly describes
+  `outside` for `HTML()` (#303).
+
 * `includeCSS()`, `includeHTML()`, `includeText()`, `includeMarkdown()`, and `includeScript()` now raise a clear error naming the missing file when `path` does not exist, instead of the vague "cannot open the connection" message from `readLines()`. (rstudio/shiny#1757)
 
 

--- a/R/tags.R
+++ b/R/tags.R
@@ -765,7 +765,7 @@ hr <- tags$hr
 #' @param varArgs List of tag attributes and children.
 #' @param .noWS Character vector used to omit some of the whitespace that would
 #'   normally be written around this tag. Valid options include `before`,
-#'   `after`, `outside`, `after-begin`, and `before-end`.
+#'   `after`, `outside`, `after-begin`, `before-end`, and `inside`.
 #'   Any number of these options can be specified.
 #' @param .renderHook A function (or list of functions) to call when the `tag` is rendered. This
 #'   function should have at least one argument (the `tag`) and return anything
@@ -1157,7 +1157,7 @@ resolveFunctionalDependencies <- function(dependencies) {
 #' @param .noWS Character vector used to omit some of the whitespace that would
 #'   normally be written around this HTML. Valid options include `before`,
 #'   `after`, and `outside` (equivalent to `before` and
-#'   `end`).
+#'   `after`).
 #' @return The input `text`, but marked as HTML.
 #'
 #' @examples

--- a/man/HTML.Rd
+++ b/man/HTML.Rd
@@ -15,7 +15,7 @@ concatenated together}
 \item{.noWS}{Character vector used to omit some of the whitespace that would
 normally be written around this HTML. Valid options include \code{before},
 \code{after}, and \code{outside} (equivalent to \code{before} and
-\code{end}).}
+\code{after}).}
 }
 \value{
 The input \code{text}, but marked as HTML.

--- a/man/builder.Rd
+++ b/man/builder.Rd
@@ -75,7 +75,7 @@ A named argument with an \code{NA} value is rendered as a boolean attributes
 
 \item{.noWS}{Character vector used to omit some of the whitespace that would
 normally be written around this tag. Valid options include \code{before},
-\code{after}, \code{outside}, \code{after-begin}, and \code{before-end}.
+\code{after}, \code{outside}, \code{after-begin}, \code{before-end}, and \code{inside}.
 Any number of these options can be specified.}
 
 \item{.renderHook}{A function (or list of functions) to call when the \code{tag} is rendered. This


### PR DESCRIPTION
Fixes #303.

This fixes two `.noWS` documentation issues:

- list `inside` as a valid option for tags
- correct the `HTML()` description of `outside` to say it is equivalent to `before` and `after`

Checks:
- `Rscript -e 'tools::checkRd("man/builder.Rd"); tools::checkRd("man/HTML.Rd")'`\n- `git diff --check`\n- `R CMD build --no-build-vignettes .`\n- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes --no-tests htmltools_0.5.9.9000.tar.gz`