### PR TITLE
Document htmlDependency examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # htmltools (development version)
 
+* `htmlDependency()` now includes examples showing dependencies from local
+  files, URL-based dependencies with script attributes, and package-bundled
+  dependencies created from a runtime wrapper (#362).
+
 * The `.noWS` documentation now lists `inside` for tags and correctly describes
   `outside` for `HTML()` (#303).
 

--- a/R/html_dependency.R
+++ b/R/html_dependency.R
@@ -88,6 +88,48 @@
 #'   The shape of the `htmlDependency` object is described (in TypeScript code)
 #'   [here](https://github.com/rstudio/shiny/blob/474f1400/srcts/src/shiny/render.ts#L79-L115).
 #'
+#' @examples
+#' # A dependency from files on disk. The script and stylesheet paths are
+#' # relative to the dependency's `src` directory.
+#' dir <- tempfile("html-dependency-")
+#' dir.create(dir)
+#' writeLines("console.log('demo dependency');", file.path(dir, "demo.js"))
+#' writeLines(".demo { color: steelblue; }", file.path(dir, "demo.css"))
+#'
+#' htmlDependency(
+#'   name = "demo",
+#'   version = "1.0.0",
+#'   src = dir,
+#'   script = "demo.js",
+#'   stylesheet = "demo.css"
+#' )
+#'
+#' # A dependency loaded from a URL can use `href` and script attributes such as
+#' # integrity and crossorigin.
+#' htmlDependency(
+#'   name = "demo-cdn",
+#'   version = "1.0.0",
+#'   src = c(href = "https://example.com/demo/1.0.0"),
+#'   script = list(
+#'     src = "demo.min.js",
+#'     integrity = "sha384-...",
+#'     crossorigin = "anonymous"
+#'   )
+#' )
+#'
+#' # If dependency files live under a package's inst/ directory, wrap the
+#' # dependency in a function and use a relative `src` with `package`.
+#' myDependency <- function() {
+#'   htmlDependency(
+#'     name = "my-package-assets",
+#'     version = "1.0.0",
+#'     src = "www",
+#'     package = "mypackage",
+#'     script = "app.js",
+#'     stylesheet = "app.css"
+#'   )
+#' }
+#'
 #' @export
 htmlDependency <- function(name,
                            version,

--- a/man/htmlDependency.Rd
+++ b/man/htmlDependency.Rd
@@ -112,6 +112,49 @@ calling \code{htmlDependency} at build-time, it should be called at
 run-time. This can be done by wrapping the \code{htmlDependency} call in a
 function.
 }
+\examples{
+# A dependency from files on disk. The script and stylesheet paths are
+# relative to the dependency's `src` directory.
+dir <- tempfile("html-dependency-")
+dir.create(dir)
+writeLines("console.log('demo dependency');", file.path(dir, "demo.js"))
+writeLines(".demo { color: steelblue; }", file.path(dir, "demo.css"))
+
+htmlDependency(
+  name = "demo",
+  version = "1.0.0",
+  src = dir,
+  script = "demo.js",
+  stylesheet = "demo.css"
+)
+
+# A dependency loaded from a URL can use `href` and script attributes such as
+# integrity and crossorigin.
+htmlDependency(
+  name = "demo-cdn",
+  version = "1.0.0",
+  src = c(href = "https://example.com/demo/1.0.0"),
+  script = list(
+    src = "demo.min.js",
+    integrity = "sha384-...",
+    crossorigin = "anonymous"
+  )
+)
+
+# If dependency files live under a package's inst/ directory, wrap the
+# dependency in a function and use a relative `src` with `package`.
+myDependency <- function() {
+  htmlDependency(
+    name = "my-package-assets",
+    version = "1.0.0",
+    src = "www",
+    package = "mypackage",
+    script = "app.js",
+    stylesheet = "app.css"
+  )
+}
+
+}
 \seealso{
 Use \code{\link[=attachDependencies]{attachDependencies()}} to associate a list of
 dependencies with the HTML it belongs with.


### PR DESCRIPTION
Closes #362.\n\nThis adds runnable examples for common htmlDependency() usage patterns:\n\n- local file-based dependencies with script and stylesheet assets\n- URL-based dependencies with script attributes such as integrity and crossorigin\n- package-bundled dependencies created from a runtime wrapper\n\nChecks run locally:\n- Rscript -e 'tools::checkRd("man/htmlDependency.Rd")'\n- git diff --check\n- direct Rscript dry run of the added examples\n- R CMD build --no-build-vignettes .